### PR TITLE
Hotfix unit testing jsonString construction culture settings

### DIFF
--- a/Apsitvarkom.UnitTests/DataAccess/PollutedLocationsFileRepositoryTests.cs
+++ b/Apsitvarkom.UnitTests/DataAccess/PollutedLocationsFileRepositoryTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Globalization;
+using System.Text.Json;
 using Apsitvarkom.DataAccess;
 using static Apsitvarkom.Models.Enumerations;
 
@@ -23,7 +24,7 @@ public class PollutedLocationsFileRepositoryTests
             $"\"id\":\"{id}\"," +
             "\"location\":" +
             "{" +
-            $"\"longitude\":{longitude}," +
+            $"\"longitude\":{longitude.ToString(CultureInfo.InvariantCulture)}," +
             "}," +
             $"\"severity\":\"{severity}\"," +
             $"\"spotted\":\"{creationTime}\"," +
@@ -61,8 +62,8 @@ public class PollutedLocationsFileRepositoryTests
             $"\"id\":\"{id}\"," +
             "\"location\":" +
             "{" +
-            $"\"longitude\":{longitude}," +
-            $"\"latitude\":{latitude}" +
+            $"\"longitude\":{longitude.ToString(CultureInfo.InvariantCulture)}," +
+            $"\"latitude\":{latitude.ToString(CultureInfo.InvariantCulture)}" +
             "}," +
             $"\"radius\":{radius}," +
             $"\"severity\":\"{severity}\"," +


### PR DESCRIPTION
## What was done

Fix `ToString` for doubles to ignore culture settings when constructing jsonString
