### PR TITLE
Extend DTO validations

### DIFF
--- a/Apsitvarkom.Models/DTO/PollutedLocationDTO.cs
+++ b/Apsitvarkom.Models/DTO/PollutedLocationDTO.cs
@@ -52,18 +52,12 @@ public class PollutedLocationDTOValidator : AbstractValidator<PollutedLocationDT
     /// </summary>
     /// <param name="id">String to be parsed.</param>
     /// <returns>Flag of whether the validation was successful.</returns>
-    private bool BeValidGuid(string? id)
-    {
-        return Guid.TryParse(id, out _);
-    }
+    private bool BeValidGuid(string? id) => Guid.TryParse(id, out _);
 
     /// <summary>
     /// Checks whether input string is parseable as <see cref="DateTime"/>.
     /// </summary>
     /// <param name="date">Input to be parsed.</param>
     /// <returns>Flag of whether the validation was successful</returns>
-    private bool BeDateOfValidFormat(string? date)
-    {
-        return DateTime.TryParse(date, CultureInfo.InvariantCulture, DateTimeStyles.None, out _);
-    }
+    private bool BeDateOfValidFormat(string? date) => DateTime.TryParse(date, CultureInfo.InvariantCulture, DateTimeStyles.None, out _);
 }

--- a/Apsitvarkom.Models/DTO/PollutedLocationDTO.cs
+++ b/Apsitvarkom.Models/DTO/PollutedLocationDTO.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using System.Globalization;
 
 namespace Apsitvarkom.Models.DTO;
 
@@ -33,10 +34,10 @@ public class PollutedLocationDTOValidator : AbstractValidator<PollutedLocationDT
 {
     public PollutedLocationDTOValidator()
     {
-        RuleFor(dto => dto.Id).NotEmpty();
+        RuleFor(dto => dto.Id).NotEmpty().Must(BeValidGuid);
         RuleFor(dto => dto.Radius).NotNull();
-        RuleFor(dto => dto.Severity).NotEmpty();
-        RuleFor(dto => dto.Spotted).NotEmpty();
+        RuleFor(dto => dto.Severity).NotEmpty().IsEnumName(typeof(Enumerations.LocationSeverityLevel));
+        RuleFor(dto => dto.Spotted).NotEmpty().Must(BeDateOfValidFormat);
         RuleFor(dto => dto.Progress).NotNull();
         RuleFor(dto => dto.Notes).NotNull();
 
@@ -44,5 +45,25 @@ public class PollutedLocationDTOValidator : AbstractValidator<PollutedLocationDT
         RuleFor(dto => dto.Location).NotNull();
         // Validate all Location fields using its validator if it has a value
         RuleFor(dto => dto.Location!.Value).SetValidator(new LocationDTOValidator()).When(dto => dto.Location.HasValue);
+    }
+
+    /// <summary>
+    /// Checks whether the input Id is parseable as <see cref="Guid"/>.
+    /// </summary>
+    /// <param name="id">String to be parsed.</param>
+    /// <returns>Flag of whether the validation was successful.</returns>
+    private bool BeValidGuid(string? id)
+    {
+        return Guid.TryParse(id, out _);
+    }
+
+    /// <summary>
+    /// Checks whether input string is parseable as Date.
+    /// </summary>
+    /// <param name="date">Input to be parsed.</param>
+    /// <returns>Flag of whether the validation was successful</returns>
+    private bool BeDateOfValidFormat(string? date)
+    {
+        return DateTime.TryParse(date, CultureInfo.InvariantCulture, DateTimeStyles.None, out _);
     }
 }

--- a/Apsitvarkom.Models/DTO/PollutedLocationDTO.cs
+++ b/Apsitvarkom.Models/DTO/PollutedLocationDTO.cs
@@ -58,7 +58,7 @@ public class PollutedLocationDTOValidator : AbstractValidator<PollutedLocationDT
     }
 
     /// <summary>
-    /// Checks whether input string is parseable as Date.
+    /// Checks whether input string is parseable as <see cref="DateTime"/>.
     /// </summary>
     /// <param name="date">Input to be parsed.</param>
     /// <returns>Flag of whether the validation was successful</returns>

--- a/Apsitvarkom.Models/Mapping/PollutedLocationProfile.cs
+++ b/Apsitvarkom.Models/Mapping/PollutedLocationProfile.cs
@@ -15,9 +15,9 @@ public class PollutedLocationProfile : Profile
         // PollutedLocationDTO to PollutedLocation
         CreateMap<PollutedLocationDTO, PollutedLocation>()
             .ForMember(dest => dest.Id, opt => opt
-                .MapFrom(src => Guid.Parse(src.Id ?? string.Empty)))
+                .MapFrom(src => Guid.Parse(src.Id!)))
             .ForMember(dest => dest.Spotted, opt => opt
-                .MapFrom(src => DateTime.Parse(src.Spotted ?? string.Empty, CultureInfo.InvariantCulture)));
+                .MapFrom(src => DateTime.Parse(src.Spotted!, CultureInfo.InvariantCulture)));
 
         // LocationDTO to Location
         CreateMap<LocationDTO, Location>();

--- a/Apsitvarkom.UnitTests/Models/Validation/PollutedLocationDTOValidationTests.cs
+++ b/Apsitvarkom.UnitTests/Models/Validation/PollutedLocationDTOValidationTests.cs
@@ -27,7 +27,7 @@ public class PollutedLocationDTOValidationTests
         {
             // The DTO does not have to comply to business requirements
             // They should be handled when validating PollutedLocation (not the DTO)
-            Id = "hey",
+            Id = "378a4760-6fb9-42a9-87b2-1cece5913ffd",
             Location = new LocationDTO
             {
                 Latitude = 0,
@@ -36,8 +36,8 @@ public class PollutedLocationDTOValidationTests
             Notes = "",
             Progress = 0,
             Radius = 0,
-            Severity = "Whatever",
-            Spotted = "timestamp"
+            Severity = "Low",
+            Spotted = "1889-04-20"
         },
     };
 
@@ -79,6 +79,51 @@ public class PollutedLocationDTOValidationTests
             Radius = 0,
             Severity = "Whatever",
             Spotted = "timestamp"
+        },
+        new()
+        { 
+            // Invalid Guid, DTOValidator should throw errors
+            Id = "Invalid Guid 45621e-9898-sd-565",
+            Location = new LocationDTO
+            {
+                Latitude = 1,
+                Longitude = 2,
+            },
+            Notes = "",
+            Progress = 0,
+            Radius = 0,
+            Severity = "Moderate",
+            Spotted = "2000-02-12"
+        },
+        new()
+        {
+            // Invalid Severity, DTOValidator should throw
+            Id = "771973aa-470f-4996-8b54-d4c0bcfff94b",
+            Location = new LocationDTO
+            {
+                Latitude = 1,
+                Longitude = 2,
+            },
+            Notes = "",
+            Progress = 0,
+            Radius = 0,
+            Severity = "Whatever",
+            Spotted = "1111-02-11"
+        },
+         new()
+        {
+            // Invalid Spotted date format, DTOValidator should throw
+            Id = "771973aa-470f-4996-8b54-d4c0bcfff94b",
+            Location = new LocationDTO
+            {
+                Latitude = 1,
+                Longitude = 2,
+            },
+            Notes = "",
+            Progress = 0,
+            Radius = 0,
+            Severity = "Low",
+            Spotted = "1nv4l1d d4t3"
         },
     };
 

--- a/Apsitvarkom.UnitTests/Models/Validation/PollutedLocationDTOValidationTests.cs
+++ b/Apsitvarkom.UnitTests/Models/Validation/PollutedLocationDTOValidationTests.cs
@@ -37,7 +37,7 @@ public class PollutedLocationDTOValidationTests
             Progress = 0,
             Radius = 0,
             Severity = "Low",
-            Spotted = "1889-04-20"
+            Spotted = "2022-02-04T13:56:22Z"
         },
     };
 
@@ -62,7 +62,7 @@ public class PollutedLocationDTOValidationTests
         new()
         {
             // Location (special case - not a primitive) is missing
-            Id = "hey",
+            Id = "cc3e7aec-05cc-4aea-8d6f-47fe456536de",
             Notes = "",
             Progress = 0,
             Radius = 0,
@@ -72,7 +72,7 @@ public class PollutedLocationDTOValidationTests
         new()
         {
             // Location (special case - not a primitive) fields are not initialized
-            Id = "hey",
+            Id = "937327c5-3c8f-4ee1-b32b-43613f6bd0db",
             Location = new LocationDTO(),
             Notes = "",
             Progress = 0,
@@ -93,7 +93,7 @@ public class PollutedLocationDTOValidationTests
             Progress = 0,
             Radius = 0,
             Severity = "Moderate",
-            Spotted = "2000-02-12"
+            Spotted = "2022-02-04T13:56:22Z"
         },
         new()
         {
@@ -108,7 +108,7 @@ public class PollutedLocationDTOValidationTests
             Progress = 0,
             Radius = 0,
             Severity = "Whatever",
-            Spotted = "1111-02-11"
+            Spotted = "2002-04-04T13:12:22Z"
         },
          new()
         {


### PR DESCRIPTION
DTO validation was extended so that it would check whether **Severity**, **Spotted** and **Id** is of valid format so it could be mapped.  #28 for more context.


