### PR TITLE
Setup Entity Framework for PollutedLocation

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -78,3 +78,5 @@ jobs:
           flags: --allow-unauthenticated --port=80
           env_vars: |
             ASPNETCORE_ENVIRONMENT=Staging
+          secrets: |
+            ConnectionStrings__ApsitvarkomDatabase=${{ secrets.APSITVARKOM_DATABASE_CONNECTION_STRING }}:latest

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -80,4 +80,4 @@ jobs:
           env_vars: |
             ASPNETCORE_ENVIRONMENT=Staging
           secrets: |
-            ConnectionStrings__ApsitvarkomDatabase=${{ secrets.APSITVARKOM_DATABASE_CONNECTION_STRING }}:latest
+            ConnectionStrings__ApsitvarkomDatabase="${{ secrets.APSITVARKOM_DATABASE_CONNECTION_STRING }}":latest

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -80,4 +80,4 @@ jobs:
           env_vars: |
             ASPNETCORE_ENVIRONMENT=Staging
           secrets: |
-            ConnectionStrings__ApsitvarkomDatabase="${{ secrets.APSITVARKOM_DATABASE_CONNECTION_STRING }}":latest
+            ConnectionStrings__ApsitvarkomDatabase=ApsitvarkomDatabaseConnectionString:latest

--- a/Apsitvarkom.Api/Program.cs
+++ b/Apsitvarkom.Api/Program.cs
@@ -43,19 +43,16 @@ if (app.Environment.IsDevelopment() || app.Environment.IsStaging())
     app.UseSwagger();
     app.UseSwaggerUI();
 
-    using (var scope = app.Services.CreateScope())
-    {
-        var services = scope.ServiceProvider;
-        var pollutedLocationContext = services.GetRequiredService<PollutedLocationContext>();
+    using var scope = app.Services.CreateScope();
+    var services = scope.ServiceProvider;
+    var pollutedLocationContext = services.GetRequiredService<PollutedLocationContext>();
 
-        // TODO: switch to migrations
-        pollutedLocationContext.Database.EnsureCreated();
+    // TODO: switch to migrations
+    pollutedLocationContext.Database.EnsureCreated();
 
-        if (!pollutedLocationContext.PollutedLocations.Any())
-            DbInitializer.InitializePollutedLocations(pollutedLocationContext);
-    }
+    if (!pollutedLocationContext.PollutedLocations.Any())
+        DbInitializer.InitializePollutedLocations(pollutedLocationContext);
 }
-
 
 app.UseCors(FrontEndPolicy);
 app.UseAuthorization();

--- a/Apsitvarkom.Api/Program.cs
+++ b/Apsitvarkom.Api/Program.cs
@@ -4,6 +4,7 @@ using Apsitvarkom.Models.DTO;
 using Apsitvarkom.Models.Mapping;
 using AutoMapper;
 using FluentValidation;
+using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -20,6 +21,8 @@ builder.Services.AddCors(options =>
 {
     options.AddPolicy(FrontEndPolicy, policy => policy.WithOrigins(builder.Configuration.GetValue<string>("FrontEndOrigin")));
 });
+
+builder.Services.AddDbContext<PollutedLocationContext>(options => options.UseNpgsql(builder.Configuration.GetConnectionString("ApsitvarkomDatabase")));
 
 builder.Services.AddScoped<ILocationDTORepository<PollutedLocationDTO>>(serviceProvider =>
 {
@@ -44,6 +47,14 @@ if (app.Environment.IsDevelopment() || app.Environment.IsStaging())
 {
     app.UseSwagger();
     app.UseSwaggerUI();
+}
+
+using (var scope = app.Services.CreateScope())
+{
+    var services = scope.ServiceProvider;
+    var context = services.GetRequiredService<PollutedLocationContext>();
+    context.Database.EnsureCreated();
+    // DbInitializer.Initialize(context);
 }
 
 app.UseCors(FrontEndPolicy);

--- a/Apsitvarkom.Api/Program.cs
+++ b/Apsitvarkom.Api/Program.cs
@@ -47,15 +47,16 @@ if (app.Environment.IsDevelopment() || app.Environment.IsStaging())
 {
     app.UseSwagger();
     app.UseSwaggerUI();
+
+    using (var scope = app.Services.CreateScope())
+    {
+        var services = scope.ServiceProvider;
+        var context = services.GetRequiredService<PollutedLocationContext>();
+        context.Database.EnsureCreated();
+        DbInitializer.InitializePollutedLocations(context);
+    }
 }
 
-using (var scope = app.Services.CreateScope())
-{
-    var services = scope.ServiceProvider;
-    var context = services.GetRequiredService<PollutedLocationContext>();
-    context.Database.EnsureCreated();
-    // DbInitializer.Initialize(context);
-}
 
 app.UseCors(FrontEndPolicy);
 app.UseAuthorization();

--- a/Apsitvarkom.Api/appsettings.json
+++ b/Apsitvarkom.Api/appsettings.json
@@ -8,5 +8,8 @@
   },
   "Geocoding" : {
     "Url": "https://maps.googleapis.com/maps/api/geocode/"
+  },
+  "ConnectionStrings": {
+    "ApsitvarkomDatabase": "Host=localhost;Username=postgres;Password=devpassword;Database=apsitvarkomdev"
   }
 }

--- a/Apsitvarkom.DataAccess/Apsitvarkom.DataAccess.csproj
+++ b/Apsitvarkom.DataAccess/Apsitvarkom.DataAccess.csproj
@@ -12,6 +12,9 @@
   </ItemGroup>
   
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.10" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7" />
     <PackageReference Include="Yoh.Text.Json.NamingPolicies" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/Apsitvarkom.DataAccess/DbInitializer.cs
+++ b/Apsitvarkom.DataAccess/DbInitializer.cs
@@ -1,0 +1,149 @@
+﻿using Apsitvarkom.Models;
+
+namespace Apsitvarkom.DataAccess;
+
+/// <summary>
+/// Responsible for initializing fake data to databases
+/// </summary>
+public static class DbInitializer
+{
+    public static void InitializePollutedLocations(PollutedLocationContext context)
+    {
+        if (context.PollutedLocations.Any())
+        {
+            return;
+        }
+
+        var fakePollutedLocations = new PollutedLocation[]
+        {
+            new()
+            {
+                Id = new Guid("02f16033-232b-42e4-bfe7-1f9a223a1446"),
+                Coordinates = new()
+                {
+                    Latitude = 54.691452,
+                    Longitude = 25.266276
+                },
+                Radius = 5,
+                Severity = Enumerations.LocationSeverityLevel.Moderate,
+                Spotted = DateTime.Parse("2019-08-23T14:05:43Z").ToUniversalTime(),
+                Progress = 41,
+                Notes = "Prisoners broke a window."
+            },
+            new()
+            {
+                Id = new Guid("461911ac-ff85-41f8-860a-be0240f0653f"),
+                Coordinates = new()
+                {
+                    Latitude = 54.675369,
+                    Longitude = 25.273316
+                },
+                Radius = 1,
+                Severity = Enumerations.LocationSeverityLevel.Low,
+                Spotted = DateTime.Parse("2023-04-13T07:16:55Z").ToUniversalTime(),
+                Progress = 13,
+                Notes = "A lot of cigarettes waste on the pavement."
+            },
+            new()
+            {
+                Id = new Guid("b2ed322d-331b-4f28-9dbf-4a71dce7504e"),
+                Coordinates = new()
+                {
+                    Latitude = 54.728796,
+                    Longitude = 25.264199
+                },
+                Radius = 21,
+                Severity = Enumerations.LocationSeverityLevel.High,
+                Spotted = DateTime.Parse("2023-03-12T23:41:21Z").ToUniversalTime(),
+                Progress = 80,
+            },
+            new()
+            {
+                Id = new Guid("bdd6bfe1-85ec-4de5-b0e3-2e5480ef1ee0"),
+                Coordinates = new()
+                {
+                    Latitude = 54.878315,
+                    Longitude = 23.883123
+                },
+                Radius = 11,
+                Severity = Enumerations.LocationSeverityLevel.Low,
+                Spotted = DateTime.Parse("2023-11-11T11:11:11Z").ToUniversalTime(),
+                Progress = 11,
+                Notes = "Apsitvarkom to the moooooon"
+            },
+            new()
+            {
+                Id = new Guid("65f52593-8507-4474-a522-188a2dc53208"),
+                Coordinates = new()
+                {
+                    Latitude = 54.891692,
+                    Longitude = 23.914362
+                },
+                Radius = 150,
+                Severity = Enumerations.LocationSeverityLevel.Low,
+                Spotted = DateTime.Parse("2023-07-11T02:13:14Z").ToUniversalTime(),
+                Progress = 0,
+                Notes = "After the celebration of the latest Euroleague trophy, Zalgiris fans have left the grass trashy."
+            },
+            new()
+            {
+                Id = new Guid("d37c6b91-6363-44ce-99a8-2f15287cc5ab"),
+                Coordinates = new()
+                {
+                    Latitude = 54.686762,
+                    Longitude = 25.291317
+                },
+                Radius = 10,
+                Severity = Enumerations.LocationSeverityLevel.High,
+                Spotted = DateTime.Parse("2023-01-01T04:00:01Z").ToUniversalTime(),
+                Progress = 0,
+                Notes = "The Vilnius Castle has slipped off the mountain."
+            },
+            new()
+            {
+                Id = new Guid("151757e9-fce3-4bb3-93db-08b93d71245e"),
+                Coordinates = new()
+                {
+                    Latitude = 55.730551,
+                    Longitude = 24.394250
+                },
+                Radius = 50,
+                Severity = Enumerations.LocationSeverityLevel.Low,
+                Spotted = DateTime.Parse("2022-06-08T01:12:23Z").ToUniversalTime(),
+                Progress = 80,
+                Notes = "Couldn't manage to grab all the beer cans I found on the beach."
+            },
+            new()
+            {
+                Id = new Guid("9de943d3-3ac6-4c55-adcf-fc6aa79b0597"),
+                Coordinates = new()
+                {
+                    Latitude = 55.705656,
+                    Longitude = 21.122825
+                },
+                Radius = 200,
+                Severity = Enumerations.LocationSeverityLevel.Low,
+                Spotted = DateTime.Parse("2023-04-01T13:14:15Z").ToUniversalTime(),
+                Progress = 0,
+                Notes = "Maybe we should tidy this up as the tourists see this place first of our whole city."
+            },
+            new()
+            {
+                Id = new Guid("dc1513da-a60b-49e5-adba-d0aeed77f125"),
+                Coordinates = new()
+                {
+                    Latitude = 56.293939,
+                    Longitude = 22.340248
+                },
+                Radius = 50,
+                Severity = Enumerations.LocationSeverityLevel.Moderate,
+                Spotted = DateTime.Parse("2022-06-20T11:22:33Z").ToUniversalTime(),
+                Progress = 20,
+                Notes = "The fans made a big mess after the game. Apsitvarkom?"
+            },
+        };
+
+        context.PollutedLocations.AddRange(fakePollutedLocations);
+        context.SaveChanges();
+    }
+}

--- a/Apsitvarkom.DataAccess/DbInitializer.cs
+++ b/Apsitvarkom.DataAccess/DbInitializer.cs
@@ -9,11 +9,6 @@ public static class DbInitializer
 {
     public static void InitializePollutedLocations(PollutedLocationContext context)
     {
-        if (context.PollutedLocations.Any())
-        {
-            return;
-        }
-
         var fakePollutedLocations = new PollutedLocation[]
         {
             new()

--- a/Apsitvarkom.DataAccess/PollutedLocationContext.cs
+++ b/Apsitvarkom.DataAccess/PollutedLocationContext.cs
@@ -11,6 +11,10 @@ public class PollutedLocationContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        // Coordinates must be specified as an owned entity type
+        // Reference: https://learn.microsoft.com/en-us/ef/core/modeling/owned-entities
         modelBuilder.Entity<PollutedLocation>().OwnsOne(l => l.Coordinates);
+
+        //modelBuilder.Entity<PollutedLocation>().Property(l => l.Spotted).Typ;
     }
 }

--- a/Apsitvarkom.DataAccess/PollutedLocationContext.cs
+++ b/Apsitvarkom.DataAccess/PollutedLocationContext.cs
@@ -1,0 +1,16 @@
+﻿using Apsitvarkom.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Apsitvarkom.DataAccess;
+
+public class PollutedLocationContext : DbContext
+{
+    public DbSet<PollutedLocation> PollutedLocations { get; set; } = null!;
+
+    public PollutedLocationContext(DbContextOptions<PollutedLocationContext> options) : base(options) { }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<PollutedLocation>().OwnsOne(l => l.Coordinates);
+    }
+}

--- a/Apsitvarkom.DataAccess/PollutedLocationContext.cs
+++ b/Apsitvarkom.DataAccess/PollutedLocationContext.cs
@@ -14,7 +14,5 @@ public class PollutedLocationContext : DbContext
         // Coordinates must be specified as an owned entity type
         // Reference: https://learn.microsoft.com/en-us/ef/core/modeling/owned-entities
         modelBuilder.Entity<PollutedLocation>().OwnsOne(l => l.Coordinates);
-
-        //modelBuilder.Entity<PollutedLocation>().Property(l => l.Spotted).Typ;
     }
 }

--- a/Apsitvarkom.DataAccess/PollutedLocationDTODatabaseRepository.cs
+++ b/Apsitvarkom.DataAccess/PollutedLocationDTODatabaseRepository.cs
@@ -1,0 +1,29 @@
+﻿using Apsitvarkom.Models;
+using Apsitvarkom.Models.DTO;
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+
+namespace Apsitvarkom.DataAccess;
+
+public class PollutedLocationDTODatabaseRepository : ILocationDTORepository<PollutedLocationDTO>
+{
+    private readonly PollutedLocationContext _context;
+    private readonly IMapper _mapper;
+
+    public PollutedLocationDTODatabaseRepository(PollutedLocationContext context, IMapper mapper)
+    {
+        _context = context;
+        _mapper = mapper;
+    }
+
+    public async Task<IEnumerable<PollutedLocationDTO>> GetAllAsync()
+    {
+        var models = await _context.PollutedLocations.ToListAsync();
+
+        return _mapper.Map<List<PollutedLocation>, IEnumerable<PollutedLocationDTO>>(models);
+    }
+
+    public Task<IEnumerable<PollutedLocationDTO>> GetAllAsync(Location inRelationTo) => throw new NotImplementedException();
+
+    public Task<PollutedLocationDTO?> GetByPropertyAsync(Func<PollutedLocationDTO, bool> propertyCondition) => throw new NotImplementedException();
+}

--- a/Apsitvarkom.Models/DTO/LocationDTO.cs
+++ b/Apsitvarkom.Models/DTO/LocationDTO.cs
@@ -3,7 +3,7 @@
 namespace Apsitvarkom.Models.DTO;
 
 /// <summary>DTO equivalent of <see cref="Coordinates"/>.</summary>
-public struct CoordinatesDTO
+public class CoordinatesDTO
 {
     public double? Longitude { get; set; }
     public double? Latitude { get; set; }
@@ -32,6 +32,6 @@ public class LocationDTOValidator : AbstractValidator<LocationDTO>
     public LocationDTOValidator()
     {
         RuleFor(dto => dto.Coordinates).NotNull();
-        RuleFor(dto => dto.Coordinates!.Value).SetValidator(new CoordinatesDTOValidator()).When(dto => dto.Coordinates.HasValue);
+        RuleFor(dto => dto.Coordinates!).SetValidator(new CoordinatesDTOValidator()).When(dto => dto.Coordinates is not null);
     }
 }

--- a/Apsitvarkom.Models/DTO/PollutedLocationDTO.cs
+++ b/Apsitvarkom.Models/DTO/PollutedLocationDTO.cs
@@ -41,7 +41,6 @@ public class PollutedLocationDTOValidator : AbstractValidator<PollutedLocationDT
         RuleFor(dto => dto.Severity).NotEmpty().IsEnumName(typeof(Enumerations.LocationSeverityLevel));
         RuleFor(dto => dto.Spotted).NotEmpty().Must(BeDateOfValidFormat);
         RuleFor(dto => dto.Progress).NotNull();
-        RuleFor(dto => dto.Notes).NotNull();
     }
 
     /// <summary>

--- a/Apsitvarkom.Models/Location.cs
+++ b/Apsitvarkom.Models/Location.cs
@@ -3,9 +3,9 @@
 namespace Apsitvarkom.Models;
 
 /// <summary>
-/// Struct used for storing coordinates of a polluted location.
+/// Class used for storing coordinates of a polluted location.
 /// </summary>
-public struct Coordinates
+public class Coordinates
 {
     public double Latitude { get; set; }
     public double Longitude { get; set; }
@@ -26,7 +26,7 @@ public class CoordinatesValidator : AbstractValidator<Coordinates>
 public class Location
 {
     /// <summary>Longitude and Latitude of a location.</summary>
-    public Coordinates Coordinates { get; set; }
+    public Coordinates Coordinates { get; set; } = null!;
 }
 
 /// <summary>

--- a/Apsitvarkom.Models/PollutedLocation.cs
+++ b/Apsitvarkom.Models/PollutedLocation.cs
@@ -24,7 +24,7 @@ public class PollutedLocation : Location
     public int Progress { get; set; }
 
     /// <summary>Additional information about the record.</summary>
-    public string Notes { get; set; } = null!;
+    public string? Notes { get; set; }
 }
 
 public class PollutedLocationValidator : AbstractValidator<PollutedLocation>

--- a/README.md
+++ b/README.md
@@ -2,18 +2,23 @@
 
 Apsitvarkom back end dotnet web API
 
-## Running
+## Dependencies
 
-1. Clone the repository
-2. Start project
-   1. Visual Studio
-      1. Open up solution
-      2. Press "Play" button at the top
-   2. [`dotnet` CLI](https://docs.microsoft.com/en-us/dotnet/core/tools/)
-      1. Open a terminal in `Apsitvarkom/Apsitvarkom.Api` directory
-      2. Run `dotnet run`
-3. Visit swagger at http://localhost:5125/swagger
+- PostgreSQL (expects `ConnectionStrings:ApsitvarkomDatabase` in configuration)
+- Google Maps [Geocoding API](https://developers.google.com/maps/documentation/geocoding/overview) (expects `Geocoding:ApiKey` in configuration).
 
-## References
+## Running locally
 
-- [Web API tutorial](https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-web-api?view=aspnetcore-6.0&tabs=visual-studio)
+1. Run `docker-compose -f dev-stack.yml up` (requires [Docker](https://www.docker.com/))
+   1. This starts [PostgreSQL](https://www.postgresql.org/) on port `5432`. Database data will _be saved_ if you shut down the stack.
+   2. This starts [Adminer](https://www.adminer.org/) on port `8080`. Visit [`http://localhost:8080`](http://localhost:8080) and login in with `username: postgres` and `password: devpassword`.
+2. Run `dotnet user-secrets set "Geocoding:ApiKey" "<OUR_API_KEY>"`
+   1. Replace `<OUR_API_KEY>` with the development api key from our google sheet yourself and keep it as a secret.
+   2. This has to be done only once
+3. Start the web API (either `dotnet run` or by clicking "Play" in Visual Studio)
+   1. Visit swagger at http://localhost:5125/swagger
+
+## CICD
+
+- Every PR to `staging` branch runs CI automatically that builds, tests and reports coverage in the PR.
+- Every merge/push to `staging` branch runs CICD that automatically builds, tests, builds docker image, pushes it to an [Artifact Registry](https://cloud.google.com/artifact-registry) and then deploys it in [Cloud Run](https://cloud.google.com/run). See "Environments" on GitHub to access `staging` environment url.

--- a/dev-stack.yml
+++ b/dev-stack.yml
@@ -1,0 +1,21 @@
+version: "3.1"
+
+services:
+  db:
+    image: postgres
+    restart: always
+    ports:
+      - 5432:5432
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: devpassword
+
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 8080:8080
+
+volumes:
+  db-data:


### PR DESCRIPTION
## What was done

<!-- Describe in points what was done for easier overview -->

- Added `PollutedLocationsContext`
- Added `PollutedLocationDTODatabaseRepository`. This is now used instead of the file repository (left #82 to implement it fully and to also clean up unneeded things from file repository)
- Added `DbInitializer` that adds some fake data if the database doesn't have anything (for `development` and `staging` environments)
- Make `Notes` optional (as we've planned at the start)
- Switch `Coordinates` from `struct` to `class` (EF does not like structs)
- Updated readme with instructions on how to run the project now
- Allowed connection from the internet to our PostgreSQL VM. `staging` environment now connects to our `staging` database. Although this might not be fully sustainable, since we don't have a *static* external IP for the VM, so if it changes for some reason, we'll need to reset the connection string - so let's just wait and see how often that happens

<!-- If needed, describe your changes in detail here -->

Closes #83
