### PR TITLE
Implement GetAll(Location) overload in the PollutedLocationController

### DIFF
--- a/Apsitvarkom.Api/Controllers/PollutedLocationController.cs
+++ b/Apsitvarkom.Api/Controllers/PollutedLocationController.cs
@@ -1,4 +1,5 @@
 ﻿using Apsitvarkom.DataAccess;
+using Apsitvarkom.Models;
 using Apsitvarkom.Models.DTO;
 using Microsoft.AspNetCore.Mvc;
 
@@ -21,6 +22,15 @@ public class PollutedLocationController : ControllerBase
     public async Task<ActionResult<IEnumerable<PollutedLocationDTO>>> GetAll()
     {
         var instances = await _repository.GetAllAsync();
+        return Ok(instances);
+    }
+
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [HttpGet("All/OrderedByDistance")]
+    public async Task<ActionResult<IEnumerable<PollutedLocationDTO>>> GetAll(double latitude, double longitude)
+    {
+        var instances = await _repository.GetAllAsync(new Location { Coordinates = new Coordinates { Latitude = latitude, Longitude = longitude } } );
         return Ok(instances);
     }
 

--- a/Apsitvarkom.Models/DTO/LocationDTO.cs
+++ b/Apsitvarkom.Models/DTO/LocationDTO.cs
@@ -5,16 +5,16 @@ namespace Apsitvarkom.Models.DTO;
 /// <summary>DTO equivalent of <see cref="Coordinates"/>.</summary>
 public class CoordinatesDTO
 {
-    public double? Longitude { get; set; }
     public double? Latitude { get; set; }
+    public double? Longitude { get; set; }
 }
 
 public class CoordinatesDTOValidator : AbstractValidator<CoordinatesDTO>
 {
     public CoordinatesDTOValidator()
     {
-        RuleFor(dto => dto.Longitude).NotNull();
         RuleFor(dto => dto.Latitude).NotNull();
+        RuleFor(dto => dto.Longitude).NotNull();
     }
 }
 

--- a/Apsitvarkom.Models/Location.cs
+++ b/Apsitvarkom.Models/Location.cs
@@ -15,8 +15,8 @@ public class CoordinatesValidator : AbstractValidator<Coordinates>
 {
     public CoordinatesValidator()
     {
-        RuleFor(coordinates => coordinates.Longitude).InclusiveBetween(-180.0, 180.0);
         RuleFor(coordinates => coordinates.Latitude).InclusiveBetween(-90.0, 90.0);
+        RuleFor(coordinates => coordinates.Longitude).InclusiveBetween(-180.0, 180.0);
     }
 }
 

--- a/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
+++ b/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
@@ -80,6 +80,7 @@ public class PollutedLocationControllerTests
 
         var actionResult = await m_controller.GetAll(latitude, longitude);
 
+        Assert.That(actionResult.Result, Is.TypeOf(typeof(OkObjectResult)));
         var result = actionResult.Result as OkObjectResult;
 
         Assert.That(result, Is.Not.Null);

--- a/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
+++ b/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq.Expressions;
 using Apsitvarkom.Api.Controllers;
 using Apsitvarkom.DataAccess;
+using Apsitvarkom.Models;
 using Apsitvarkom.Models.DTO;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -61,6 +62,23 @@ public class PollutedLocationControllerTests
         m_repository.Setup(self => self.GetAllAsync()).ReturnsAsync(PollutedLocationDTOs);
 
         var actionResult = await m_controller.GetAll();
+
+        var result = actionResult.Result as OkObjectResult;
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
+        Assert.That(result.Value, Is.EqualTo(PollutedLocationDTOs));
+    }
+
+    [Test]
+    public async Task GetAll_RepositoryReturnsOrderedPollutedLocationDTOs_OKActionResultReturned()
+    {
+        const double latitude = 12.3456;
+        const double longitude = -65.4321;
+        m_repository.Setup(self => self.GetAllAsync(It.Is<Location>(x => 
+            Math.Abs(x.Coordinates.Latitude - latitude) < 0.0001 && Math.Abs(x.Coordinates.Longitude - longitude) < 0.0001))).ReturnsAsync(PollutedLocationDTOs);
+
+        var actionResult = await m_controller.GetAll(latitude, longitude);
 
         var result = actionResult.Result as OkObjectResult;
 


### PR DESCRIPTION
## What was done

- Implemented a GetAll(double latitude, double longitude) overload in the PollutedLocation Controller reachable at the EndPoint /PollutedLocation/All/OrderedByDistance
- Written a unit test to cover its behavior.
- Switched Latitude and Longitude in the PollutedLocationDTO so that our response now would go
```
    "coordinates": {
      "latitude": 54.691452,
      "longitude": 25.266276
    }
```
instead of 
```
    "coordinates": {
      "longitude": 25.266276,
      "latitude": 54.691452
    }
```