### PR TITLE
Extend PollutedLocation creation with title generation using Geocoder Part 2

### DIFF
--- a/Apsitvarkom.Api/appsettings.Staging.json
+++ b/Apsitvarkom.Api/appsettings.Staging.json
@@ -6,7 +6,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "Geocoding" : {
-    "Url": "https://maps.googleapis.com/maps/api/geocode/"
+  "Geocoding": {
+    "Url": "https://maps.googleapis.com/maps/api/geocode/",
+    "ApiKey": "AIzaSyBoJewglfM03Ho6JZxsSctXGBJ4VezA1dE"
   }
 }

--- a/Apsitvarkom.DataAccess/GoogleGeocoder.cs
+++ b/Apsitvarkom.DataAccess/GoogleGeocoder.cs
@@ -1,5 +1,6 @@
 ﻿using Apsitvarkom.Configuration;
 using Apsitvarkom.Models;
+using System.Globalization;
 using System.Text.Json;
 using Yoh.Text.Json.NamingPolicies;
 
@@ -23,7 +24,8 @@ public class GoogleGeocoder : IGeocoder
 
     public async Task<string?> ReverseGeocodeAsync(Coordinates coordinates)
     {
-        var jsonStream = await _httpClient.GetStreamAsync($"json?latlng={coordinates.Latitude},{coordinates.Longitude}&language=lt&key={_apiKey}");
+        var query = $"json?latlng={coordinates.Latitude.ToString(CultureInfo.InvariantCulture)},{coordinates.Longitude.ToString(CultureInfo.InvariantCulture)}&language=lt&key={_apiKey}";
+        var jsonStream = await _httpClient.GetStreamAsync(query);
         var response = await JsonSerializer.DeserializeAsync<ReverseGeocodingApiResponse>(jsonStream, SerializerOptions);
 
         return response?.Results?.FirstOrDefault()?.FormattedAddress;

--- a/Apsitvarkom.Mapping/PollutedLocationProfile.cs
+++ b/Apsitvarkom.Mapping/PollutedLocationProfile.cs
@@ -21,10 +21,10 @@ public class PollutedLocationProfile : Profile
     {
         CreateMap<CoordinatesCreateRequest, Coordinates>();
         CreateMap<LocationCreateRequest, Location>()
-            .ForMember(dest => dest.Title, opt => opt.MapFrom<LocationTitleResolver>());
+            .ForMember(x => x.Title, opt => opt.Ignore());
         CreateMap<PollutedLocationCreateRequest, PollutedLocation>()
-            .ForMember(dest => dest.Spotted, opt => opt.MapFrom(_ => DateTime.UtcNow))
-            .ForMember(dest => dest.Id, opt => opt.MapFrom(_ => Guid.NewGuid()));
+            .ForMember(x => x.Spotted, opt => opt.Ignore())
+            .ForMember(x => x.Id, opt => opt.Ignore());
     }
 
     private void MapResponses()
@@ -32,20 +32,5 @@ public class PollutedLocationProfile : Profile
         CreateMap<PollutedLocation, PollutedLocationResponse>();
         CreateMap<Location, LocationResponse>();
         CreateMap<Coordinates, CoordinatesResponse>();
-    }
-}
-
-public class LocationTitleResolver : IValueResolver<LocationCreateRequest, Location, string>
-{
-    private readonly IGeocoder _geocoder;
-
-    public LocationTitleResolver(IGeocoder geocoder)
-    {
-        _geocoder = geocoder;
-    }
-
-    public string Resolve(LocationCreateRequest source, Location destination, string destMember, ResolutionContext context)
-    {
-        return Task.Run(async () => await _geocoder.ReverseGeocodeAsync(destination.Coordinates)).Result ?? string.Empty;
     }
 }

--- a/Apsitvarkom.Models/PollutedLocation.cs
+++ b/Apsitvarkom.Models/PollutedLocation.cs
@@ -13,7 +13,7 @@ public class PollutedLocation
     }
 
     /// <summary>Unique identifier of the given record.</summary>
-    public Guid Id { get; init; }
+    public Guid Id { get; set; }
 
     /// <summary>Rough size estimate of the given record area in meters from the center.</summary>
     public int Radius { get; set; }
@@ -22,7 +22,7 @@ public class PollutedLocation
     public SeverityLevel Severity { get; set; }
 
     /// <summary><see cref="DateTime" /> of when the record was created.</summary>
-    public DateTime Spotted { get; init; }
+    public DateTime Spotted { get; set; }
 
     /// <summary>Current progress of the record's cleaning process in percentages.</summary>
     public int Progress { get; set; }

--- a/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
+++ b/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
@@ -61,19 +61,19 @@ public class PollutedLocationControllerTests
     [SetUp]
     public void SetUp()
     {
-        _geocoder = new Mock<IGeocoder>();
         var config = new MapperConfiguration(cfg =>
         {
-            cfg.ConstructServicesUsing(_ => new LocationTitleResolver(_geocoder.Object));
             cfg.AddProfile<PollutedLocationProfile>();
         });
         config.AssertConfigurationIsValid();
         _mapper = config.CreateMapper();
 
+        _geocoder = new Mock<IGeocoder>();
         _repository = new Mock<IPollutedLocationRepository>();
         _controller = new PollutedLocationController(
             _repository.Object, 
-            _mapper, 
+            _mapper,
+            _geocoder.Object,
             new CoordinatesCreateRequestValidator(), 
             new PollutedLocationCreateRequestValidator(new LocationCreateRequestValidator(new CoordinatesCreateRequestValidator()))
         );
@@ -84,6 +84,7 @@ public class PollutedLocationControllerTests
     public void Constructor_HappyPath_IsSuccess() => Assert.That(new PollutedLocationController(
             _repository.Object,
             _mapper,
+            _geocoder.Object,
             new CoordinatesCreateRequestValidator(),
             new PollutedLocationCreateRequestValidator(new LocationCreateRequestValidator(new CoordinatesCreateRequestValidator()))
         ), Is.Not.Null);

--- a/Apsitvarkom.UnitTests/Mapping/PollutedLocationMappingTests.cs
+++ b/Apsitvarkom.UnitTests/Mapping/PollutedLocationMappingTests.cs
@@ -1,26 +1,21 @@
 ﻿using System.Globalization;
-using Apsitvarkom.DataAccess;
 using Apsitvarkom.Models;
 using Apsitvarkom.Mapping;
 using Apsitvarkom.Models.Public;
 using AutoMapper;
-using Moq;
 
 namespace Apsitvarkom.UnitTests.Mapping;
 
 public class PollutedLocationMappingTests
 {
     private IMapper _mapper = null!;
-    private Mock<IGeocoder> _geocoder = null!;
 
     [SetUp]
     public void SetUp()
     {
-        _geocoder = new Mock<IGeocoder>();
         var config = new MapperConfiguration(cfg =>
         {
             cfg.AddProfile<PollutedLocationProfile>();
-            cfg.ConstructServicesUsing(_ => new LocationTitleResolver(_geocoder.Object));
         });
 
         config.AssertConfigurationIsValid();
@@ -67,15 +62,9 @@ public class PollutedLocationMappingTests
             }
         };
 
-        var title = "title";
-        _geocoder.Setup(self => self.ReverseGeocodeAsync(It.Is<Coordinates>(x =>
-            Math.Abs(x.Latitude - latitude) < 0.0001 && Math.Abs(x.Longitude - longitude) < 0.0001
-        ))).ReturnsAsync(title);
-
         var pollutedLocation = _mapper.Map<PollutedLocation>(pollutedLocationCreateRequest);
         Assert.Multiple(() =>
         {
-            Assert.That(pollutedLocation.Location.Title, Is.EqualTo(title));
             Assert.That(pollutedLocation.Location.Coordinates.Latitude, Is.EqualTo(latitude));
             Assert.That(pollutedLocation.Location.Coordinates.Longitude, Is.EqualTo(longitude));
             Assert.That(pollutedLocation.Notes, Is.EqualTo(notes));


### PR DESCRIPTION
## What was done

Part 2 of #107 

- Set computed properties in action instead of mapper. It appears that we were trying to use mapper in a not so intended way.
- Add staging api key (it's referrer protected, it can be in source control)
- Fix double toString bug when reverse geocoding