### PR TITLE
Sorted getAll endpoints for Locations and Events in descending order

### DIFF
--- a/Apsitvarkom.Api/Controllers/CleaningEventController.cs
+++ b/Apsitvarkom.Api/Controllers/CleaningEventController.cs
@@ -40,7 +40,7 @@ public class CleaningEventController : ControllerBase
             return StatusCode(StatusCodes.Status500InternalServerError);
         }
 
-        IEnumerable<CleaningEvent> sortedEvents = events.OrderByDescending(o => o.StartTime);
+        var sortedEvents = events.OrderByDescending(o => o.StartTime);
 
         var mappedEvents = _mapper.Map<IEnumerable<CleaningEventResponse>>(sortedEvents);
         if (mappedEvents is null) return StatusCode(StatusCodes.Status500InternalServerError);

--- a/Apsitvarkom.Api/Controllers/CleaningEventController.cs
+++ b/Apsitvarkom.Api/Controllers/CleaningEventController.cs
@@ -40,7 +40,7 @@ public class CleaningEventController : ControllerBase
             return StatusCode(StatusCodes.Status500InternalServerError);
         }
 
-        var sortedEvents = events.OrderByDescending(o => o.StartTime);
+        var sortedEvents = events.OrderBy(o => o.StartTime);
 
         var mappedEvents = _mapper.Map<IEnumerable<CleaningEventResponse>>(sortedEvents);
         if (mappedEvents is null) return StatusCode(StatusCodes.Status500InternalServerError);

--- a/Apsitvarkom.Api/Controllers/CleaningEventController.cs
+++ b/Apsitvarkom.Api/Controllers/CleaningEventController.cs
@@ -40,7 +40,9 @@ public class CleaningEventController : ControllerBase
             return StatusCode(StatusCodes.Status500InternalServerError);
         }
 
-        var mappedEvents = _mapper.Map<IEnumerable<CleaningEventResponse>>(events);
+        IEnumerable<CleaningEvent> sortedEvents = events.OrderByDescending(o => o.StartTime);
+
+        var mappedEvents = _mapper.Map<IEnumerable<CleaningEventResponse>>(sortedEvents);
         if (mappedEvents is null) return StatusCode(StatusCodes.Status500InternalServerError);
 
         return Ok(mappedEvents);

--- a/Apsitvarkom.Api/Controllers/PollutedLocationController.cs
+++ b/Apsitvarkom.Api/Controllers/PollutedLocationController.cs
@@ -52,7 +52,7 @@ public class PollutedLocationController : ControllerBase
             return StatusCode(StatusCodes.Status500InternalServerError);
         }
 
-        IEnumerable<PollutedLocation> sortedLocations = locations.OrderByDescending(o => o.Spotted);
+        var sortedLocations = locations.OrderByDescending(o => o.Spotted);
 
         var mappedLocations = _mapper.Map<IEnumerable<PollutedLocationResponse>>(sortedLocations);
         if (mappedLocations is null) return StatusCode(StatusCodes.Status500InternalServerError);

--- a/Apsitvarkom.Api/Controllers/PollutedLocationController.cs
+++ b/Apsitvarkom.Api/Controllers/PollutedLocationController.cs
@@ -52,7 +52,9 @@ public class PollutedLocationController : ControllerBase
             return StatusCode(StatusCodes.Status500InternalServerError);
         }
 
-        var mappedLocations = _mapper.Map<IEnumerable<PollutedLocationResponse>>(locations);
+        IEnumerable<PollutedLocation> sortedLocations = locations.OrderByDescending(o => o.Spotted);
+
+        var mappedLocations = _mapper.Map<IEnumerable<PollutedLocationResponse>>(sortedLocations);
         if (mappedLocations is null) return StatusCode(StatusCodes.Status500InternalServerError);
 
         return Ok(mappedLocations);

--- a/Apsitvarkom.Api/Controllers/PollutedLocationController.cs
+++ b/Apsitvarkom.Api/Controllers/PollutedLocationController.cs
@@ -52,7 +52,7 @@ public class PollutedLocationController : ControllerBase
             return StatusCode(StatusCodes.Status500InternalServerError);
         }
 
-        var sortedLocations = locations.OrderByDescending(o => o.Spotted);
+        var sortedLocations = locations.OrderBy(o => o.Spotted);
 
         var mappedLocations = _mapper.Map<IEnumerable<PollutedLocationResponse>>(sortedLocations);
         if (mappedLocations is null) return StatusCode(StatusCodes.Status500InternalServerError);

--- a/Apsitvarkom.UnitTests/Api/Controllers/CleaningEventControllerTests.cs
+++ b/Apsitvarkom.UnitTests/Api/Controllers/CleaningEventControllerTests.cs
@@ -87,7 +87,7 @@ public class CleaningEventControllerTests
         var resultEvents = result.Value as IEnumerable<CleaningEventResponse>;
         Assert.That(resultEvents, Is.Not.Null.And.Count.EqualTo(CleaningEvents.Count()));
 
-        var sortedRepositoryEvents = CleaningEvents.OrderByDescending(o => o.StartTime);
+        var sortedRepositoryEvents = CleaningEvents.OrderBy(o => o.StartTime);
 
         for (var i = 0; i < CleaningEvents.Count(); i++)
         {

--- a/Apsitvarkom.UnitTests/Api/Controllers/CleaningEventControllerTests.cs
+++ b/Apsitvarkom.UnitTests/Api/Controllers/CleaningEventControllerTests.cs
@@ -87,13 +87,12 @@ public class CleaningEventControllerTests
         var resultEvents = result.Value as IEnumerable<CleaningEventResponse>;
         Assert.That(resultEvents, Is.Not.Null.And.Count.EqualTo(CleaningEvents.Count()));
 
-        IEnumerable<CleaningEvent> sortedRepositoryEvents = CleaningEvents.OrderByDescending(o => o.StartTime);
-        IEnumerable<CleaningEventResponse> sortedResultEvents = resultEvents.OrderByDescending(o => o.StartTime);
+        var sortedRepositoryEvents = CleaningEvents.OrderByDescending(o => o.StartTime);
 
         for (var i = 0; i < CleaningEvents.Count(); i++)
         {
             var cleaningEvent = sortedRepositoryEvents.ElementAt(i);
-            var resultEvent = sortedResultEvents.ElementAt(i);
+            var resultEvent = resultEvents.ElementAt(i);
             Assert.Multiple(() =>
             {
                 Assert.That(resultEvent.Id, Is.EqualTo(cleaningEvent.Id));

--- a/Apsitvarkom.UnitTests/Api/Controllers/CleaningEventControllerTests.cs
+++ b/Apsitvarkom.UnitTests/Api/Controllers/CleaningEventControllerTests.cs
@@ -86,10 +86,14 @@ public class CleaningEventControllerTests
         Assert.That(result.Value, Is.Not.Null.And.InstanceOf<IEnumerable<CleaningEventResponse>>());
         var resultEvents = result.Value as IEnumerable<CleaningEventResponse>;
         Assert.That(resultEvents, Is.Not.Null.And.Count.EqualTo(CleaningEvents.Count()));
+
+        IEnumerable<CleaningEvent> sortedRepositoryEvents = CleaningEvents.OrderByDescending(o => o.StartTime);
+        IEnumerable<CleaningEventResponse> sortedResultEvents = resultEvents.OrderByDescending(o => o.StartTime);
+
         for (var i = 0; i < CleaningEvents.Count(); i++)
         {
-            var cleaningEvent = CleaningEvents.ElementAt(i);
-            var resultEvent = resultEvents.ElementAt(i);
+            var cleaningEvent = sortedRepositoryEvents.ElementAt(i);
+            var resultEvent = sortedResultEvents.ElementAt(i);
             Assert.Multiple(() =>
             {
                 Assert.That(resultEvent.Id, Is.EqualTo(cleaningEvent.Id));

--- a/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
+++ b/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
@@ -131,13 +131,12 @@ public class PollutedLocationControllerTests
         var resultLocations = result.Value as IEnumerable<PollutedLocationResponse>;
         Assert.That(resultLocations, Is.Not.Null.And.Count.EqualTo(PollutedLocations.Count()));
 
-        IEnumerable<PollutedLocation> sortedRepositoryLocations = PollutedLocations.OrderByDescending(o => o.Spotted);
-        IEnumerable<PollutedLocationResponse> sortedResultEvents = resultLocations.OrderByDescending(o => o.Spotted);
+        var sortedRepositoryLocations = PollutedLocations.OrderByDescending(o => o.Spotted);
 
         for (var i = 0; i < PollutedLocations.Count(); i++)
         {
             var location = sortedRepositoryLocations.ElementAt(i);
-            var resultLocation = sortedResultEvents.ElementAt(i);
+            var resultLocation = resultLocations.ElementAt(i);
             Assert.Multiple(() =>
             {
                 Assert.That(resultLocation.Id, Is.EqualTo(location.Id));

--- a/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
+++ b/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
@@ -131,7 +131,7 @@ public class PollutedLocationControllerTests
         var resultLocations = result.Value as IEnumerable<PollutedLocationResponse>;
         Assert.That(resultLocations, Is.Not.Null.And.Count.EqualTo(PollutedLocations.Count()));
 
-        var sortedRepositoryLocations = PollutedLocations.OrderByDescending(o => o.Spotted);
+        var sortedRepositoryLocations = PollutedLocations.OrderBy(o => o.Spotted);
 
         for (var i = 0; i < PollutedLocations.Count(); i++)
         {

--- a/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
+++ b/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
@@ -130,10 +130,14 @@ public class PollutedLocationControllerTests
         Assert.That(result.Value, Is.Not.Null.And.InstanceOf<IEnumerable<PollutedLocationResponse>>());
         var resultLocations = result.Value as IEnumerable<PollutedLocationResponse>;
         Assert.That(resultLocations, Is.Not.Null.And.Count.EqualTo(PollutedLocations.Count()));
+
+        IEnumerable<PollutedLocation> sortedRepositoryLocations = PollutedLocations.OrderByDescending(o => o.Spotted);
+        IEnumerable<PollutedLocationResponse> sortedResultEvents = resultLocations.OrderByDescending(o => o.Spotted);
+
         for (var i = 0; i < PollutedLocations.Count(); i++)
         {
-            var location = PollutedLocations.ElementAt(i);
-            var resultLocation = resultLocations.ElementAt(i);
+            var location = sortedRepositoryLocations.ElementAt(i);
+            var resultLocation = sortedResultEvents.ElementAt(i);
             Assert.Multiple(() =>
             {
                 Assert.That(resultLocation.Id, Is.EqualTo(location.Id));


### PR DESCRIPTION
## What was done

<!-- Describe in points what was done for easier overview -->

- Sorted getAll endpoints for Locations and events 
- slightly adjuseted tests to pass 

<!-- If needed, describe your changes in detail here -->
