### PR TITLE
Add value check constraints for database columns

### DIFF
--- a/Apsitvarkom.DataAccess/PollutedLocationContext.cs
+++ b/Apsitvarkom.DataAccess/PollutedLocationContext.cs
@@ -27,7 +27,7 @@ public class PollutedLocationContext : DbContext, IPollutedLocationContext
         modelBuilder.Entity<PollutedLocation>()
             .HasCheckConstraint("CK_PollutedLocation_Radius", "\"Radius\" >= 1")
             .HasCheckConstraint("CK_PollutedLocation_Progress", "\"Progress\" >= 0 and \"Progress\" <= 100")
-            .HasCheckConstraint("CK_PollutedLocation_Severity", $"\"Severity\" in ({string.Join(", ", ((SupportedLanguages[])Enum.GetValues(typeof(SupportedLanguages))).Select(p => $"`{p}'"))})")
+            .HasCheckConstraint("CK_PollutedLocation_Severity", $"\"Severity\" in ({string.Join(", ", ((SupportedLanguages[])Enum.GetValues(typeof(SupportedLanguages))).Select(p => $"'{p}'"))})")
             .OwnsOne(l => l.Location)
             .OwnsOne(l => l.Coordinates)
             .HasCheckConstraint("CK_Coordinates_Latitude", "\"Location_Coordinates_Latitude\" >= -90 and \"Location_Coordinates_Latitude\" <= 90")

--- a/Apsitvarkom.DataAccess/PollutedLocationContext.cs
+++ b/Apsitvarkom.DataAccess/PollutedLocationContext.cs
@@ -24,10 +24,11 @@ public class PollutedLocationContext : DbContext, IPollutedLocationContext
             v => v.ToString(),
             v => (PollutedLocation.SeverityLevel)Enum.Parse(typeof(PollutedLocation.SeverityLevel), v)
         );
+        var severityLevelsString = string.Join(", ", ((PollutedLocation.SeverityLevel[])Enum.GetValues(typeof(PollutedLocation.SeverityLevel))).Select(p => $"'{p}'"));
         modelBuilder.Entity<PollutedLocation>()
             .HasCheckConstraint("CK_PollutedLocation_Radius", "\"Radius\" >= 1")
             .HasCheckConstraint("CK_PollutedLocation_Progress", "\"Progress\" >= 0 and \"Progress\" <= 100")
-            .HasCheckConstraint("CK_PollutedLocation_Severity", $"\"Severity\" in ({string.Join(", ", ((SupportedLanguages[])Enum.GetValues(typeof(SupportedLanguages))).Select(p => $"'{p}'"))})")
+            .HasCheckConstraint("CK_PollutedLocation_Severity", $"\"Severity\" in ({severityLevelsString})")
             .OwnsOne(l => l.Location)
             .OwnsOne(l => l.Coordinates)
             .HasCheckConstraint("CK_Coordinates_Latitude", "\"Location_Coordinates_Latitude\" >= -90 and \"Location_Coordinates_Latitude\" <= 90")

--- a/Apsitvarkom.DataAccess/PollutedLocationContext.cs
+++ b/Apsitvarkom.DataAccess/PollutedLocationContext.cs
@@ -27,7 +27,7 @@ public class PollutedLocationContext : DbContext, IPollutedLocationContext
         modelBuilder.Entity<PollutedLocation>()
             .HasCheckConstraint("CK_PollutedLocation_Radius", "\"Radius\" >= 1")
             .HasCheckConstraint("CK_PollutedLocation_Progress", "\"Progress\" >= 0 and \"Progress\" <= 100")
-            .HasCheckConstraint("CK_PollutedLocation_Severity", "\"Severity\" in ('Low', 'Moderate', 'High')")
+            .HasCheckConstraint("CK_PollutedLocation_Severity", $"\"Severity\" in ({string.Join(", ", ((SupportedLanguages[])Enum.GetValues(typeof(SupportedLanguages))).Select(p => $"`{p}'"))})")
             .OwnsOne(l => l.Location)
             .OwnsOne(l => l.Coordinates)
             .HasCheckConstraint("CK_Coordinates_Latitude", "\"Location_Coordinates_Latitude\" >= -90 and \"Location_Coordinates_Latitude\" <= 90")

--- a/Apsitvarkom.DataAccess/PollutedLocationContext.cs
+++ b/Apsitvarkom.DataAccess/PollutedLocationContext.cs
@@ -20,8 +20,17 @@ public class PollutedLocationContext : DbContext, IPollutedLocationContext
     
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        // Location and coordinates must be specified as owned entity types
-        // Reference: https://learn.microsoft.com/en-us/ef/core/modeling/owned-entities
-        modelBuilder.Entity<PollutedLocation>().OwnsOne(l => l.Location).OwnsOne(l => l.Coordinates);
+        modelBuilder.Entity<PollutedLocation>().Property(x => x.Severity).HasConversion(
+            v => v.ToString(),
+            v => (PollutedLocation.SeverityLevel)Enum.Parse(typeof(PollutedLocation.SeverityLevel), v)
+        );
+        modelBuilder.Entity<PollutedLocation>()
+            .HasCheckConstraint("CK_PollutedLocation_Radius", "\"Radius\" >= 1")
+            .HasCheckConstraint("CK_PollutedLocation_Progress", "\"Progress\" >= 0 and \"Progress\" <= 100")
+            .HasCheckConstraint("CK_PollutedLocation_Severity", "\"Severity\" in ('Low', 'Moderate', 'High')")
+            .OwnsOne(l => l.Location)
+            .OwnsOne(l => l.Coordinates)
+            .HasCheckConstraint("CK_Coordinates_Latitude", "\"Location_Coordinates_Latitude\" >= -90 and \"Location_Coordinates_Latitude\" <= 90")
+            .HasCheckConstraint("CK_Coordinates_Longitude", "\"Location_Coordinates_Longitude\" >= -180 and \"Location_Coordinates_Longitude\" <= 180");
     }
 }


### PR DESCRIPTION
## What was done

- Changed the way we store Enum values in the db to the [default](https://dev.mysql.com/doc/refman/8.0/en/enum.html#:~:text=An%20ENUM%20is%20a%20string,specification%20at%20table%20creation%20time.) SQL behavior - using strings.
- Added check constraints for all PollutedLocation values. These are to be expanded with #126 

Integration testing, as was described in the issue, is unavailable using in-memory testing. Tested the behavior manually - everything seems to work fine.

Closes #129 