### PR TITLE
Allow any method for CORS policy

### DIFF
--- a/Apsitvarkom.Api/Program.cs
+++ b/Apsitvarkom.Api/Program.cs
@@ -40,7 +40,7 @@ builder.Services
 const string FrontEndPolicy = "FrontEndPolicy";
 builder.Services.AddCors(options =>
 {
-    options.AddPolicy(FrontEndPolicy, policy => policy.WithOrigins(builder.Configuration.GetValue<string>("FrontEndOrigin")).AllowAnyHeader());
+    options.AddPolicy(FrontEndPolicy, policy => policy.WithOrigins(builder.Configuration.GetValue<string>("FrontEndOrigin")).AllowAnyMethod().AllowAnyHeader());
 });
 
 builder.Services.AddScoped<IPollutedLocationContext>(provider => provider.GetRequiredService<PollutedLocationContext>());


### PR DESCRIPTION
## What was done

- Allow any method for CORS policy since I was getting blocked when sending `DELETE`
