### PR TITLE
Nullable properties cannot be set to null defect fix

### DIFF
--- a/Apsitvarkom.Api/Controllers/CleaningEventController.cs
+++ b/Apsitvarkom.Api/Controllers/CleaningEventController.cs
@@ -134,7 +134,7 @@ public class CleaningEventController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(List<string>))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [HttpPatch("Update")]
+    [HttpPut("Update")]
     public async Task<ActionResult<CleaningEventResponse>> Update(CleaningEventUpdateRequest cleaningEventUpdateRequest)
     {
         var validationResult = await _cleaningEventUpdateValidator.ValidateAsync(cleaningEventUpdateRequest);

--- a/Apsitvarkom.Api/Controllers/PollutedLocationController.cs
+++ b/Apsitvarkom.Api/Controllers/PollutedLocationController.cs
@@ -163,7 +163,7 @@ public class PollutedLocationController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(List<string>))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [HttpPatch("Update")]
+    [HttpPut("Update")]
     public async Task<ActionResult<PollutedLocationResponse>> Update(PollutedLocationUpdateRequest pollutedLocationUpdateRequest)
     {
         var validationResult = await _pollutedLocationUpdateValidator.ValidateAsync(pollutedLocationUpdateRequest);

--- a/Apsitvarkom.Models/Mapping/CleaningEventProfile.cs
+++ b/Apsitvarkom.Models/Mapping/CleaningEventProfile.cs
@@ -23,8 +23,6 @@ public class CleaningEventProfile : Profile
             .ForMember(x => x.Id, opt => opt.Ignore())
             .ForMember(x => x.PollutedLocation, opt => opt.Ignore());
         CreateMap<CleaningEventUpdateRequest, CleaningEvent>()
-            .ForMember(x => x.StartTime, opt => opt.PreCondition(src => src.StartTime is not null))
-            .ForMember(x => x.Notes, opt => opt.PreCondition(src => src.Notes is not null))
             .ForMember(x => x.PollutedLocationId, opt => opt.Ignore())
             .ForMember(x => x.PollutedLocation, opt => opt.Ignore());
     }

--- a/Apsitvarkom.Models/Mapping/PollutedLocationProfile.cs
+++ b/Apsitvarkom.Models/Mapping/PollutedLocationProfile.cs
@@ -27,14 +27,11 @@ public class PollutedLocationProfile : Profile
             .ForMember(x => x.Events, opt => opt.Ignore());
         CreateMap<ObjectIdentifyRequest, PollutedLocation>(MemberList.None)
             .ForMember(x => x.Id, opt => opt.MapFrom(x => x.Id));
-        CreateMap<PollutedLocationUpdateRequest, PollutedLocation>()
-            .ForMember(x => x.Spotted, opt => opt.Ignore())
-            .ForMember(x => x.Location, opt => opt.Ignore())
-            .ForMember(x => x.Events, opt => opt.Ignore())
-            .ForMember(x => x.Progress, opt => opt.Ignore())
-            .ForMember(x => x.Radius, opt => opt.PreCondition(src => src.Radius is not null))
-            .ForMember(x => x.Severity, opt => opt.PreCondition(src => src.Severity is not null))
-            .ForMember(x => x.Notes, opt => opt.PreCondition(src => src.Notes is not null));
+        CreateMap<PollutedLocationUpdateRequest, PollutedLocation>(MemberList.None)
+            .ForMember(x => x.Id, opt => opt.MapFrom(x => x.Id))
+            .ForMember(x => x.Radius, opt => opt.MapFrom(x => x.Radius))
+            .ForMember(x => x.Severity, opt => opt.MapFrom(x => x.Severity))
+            .ForMember(x => x.Notes, opt => opt.MapFrom(x => x.Notes));
     }
 
     private void MapResponses()

--- a/Apsitvarkom.Models/Mapping/PollutedLocationProfile.cs
+++ b/Apsitvarkom.Models/Mapping/PollutedLocationProfile.cs
@@ -31,7 +31,7 @@ public class PollutedLocationProfile : Profile
             .ForMember(x => x.Spotted, opt => opt.Ignore())
             .ForMember(x => x.Location, opt => opt.Ignore())
             .ForMember(x => x.Events, opt => opt.Ignore())
-            .ForMember(x => x.Progress, opt => opt.PreCondition(src => src.Progress is not null))
+            .ForMember(x => x.Progress, opt => opt.Ignore())
             .ForMember(x => x.Radius, opt => opt.PreCondition(src => src.Radius is not null))
             .ForMember(x => x.Severity, opt => opt.PreCondition(src => src.Severity is not null))
             .ForMember(x => x.Notes, opt => opt.PreCondition(src => src.Notes is not null));

--- a/Apsitvarkom.Models/Public/CleaningEventUpdateRequest.cs
+++ b/Apsitvarkom.Models/Public/CleaningEventUpdateRequest.cs
@@ -16,6 +16,6 @@ public class CleaningEventUpdateRequestValidator : AbstractValidator<CleaningEve
     public CleaningEventUpdateRequestValidator()
     {
         RuleFor(l => l.Id).NotNull();
-        RuleFor(l => l.StartTime).GreaterThan(DateTime.UtcNow);
+        RuleFor(l => l.StartTime).NotNull().GreaterThan(DateTime.UtcNow);
     }
 }

--- a/Apsitvarkom.Models/Public/PollutedLocationUpdateRequest.cs
+++ b/Apsitvarkom.Models/Public/PollutedLocationUpdateRequest.cs
@@ -19,6 +19,7 @@ public class PollutedLocationUpdateRequestValidator : AbstractValidator<Polluted
     public PollutedLocationUpdateRequestValidator()
     {
        RuleFor(l => l.Id).NotNull();
-       RuleFor(l => l.Radius).GreaterThanOrEqualTo(1);
+       RuleFor(l => l.Radius).NotNull().GreaterThanOrEqualTo(1);
+       RuleFor(l => l.Severity).NotNull();
     }
 }

--- a/Apsitvarkom.Models/Public/PollutedLocationUpdateRequest.cs
+++ b/Apsitvarkom.Models/Public/PollutedLocationUpdateRequest.cs
@@ -11,8 +11,6 @@ public class PollutedLocationUpdateRequest
 
     public SeverityLevel? Severity { get; set; }
 
-    public int? Progress { get; set; }
-
     public string? Notes { get; set; }
 }
 
@@ -22,6 +20,5 @@ public class PollutedLocationUpdateRequestValidator : AbstractValidator<Polluted
     {
        RuleFor(l => l.Id).NotNull();
        RuleFor(l => l.Radius).GreaterThanOrEqualTo(1);
-       RuleFor(l => l.Progress).InclusiveBetween(0, 100);
     }
 }

--- a/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
+++ b/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
@@ -519,7 +519,6 @@ public class PollutedLocationControllerTests
         var updateRequest = new PollutedLocationUpdateRequest
         {
             Id = Guid.NewGuid(),
-            Progress = 12,
             Radius = 3,
             Severity = PollutedLocation.SeverityLevel.High
         };
@@ -543,7 +542,6 @@ public class PollutedLocationControllerTests
         var updateRequest = new PollutedLocationUpdateRequest
         {
             Id = Guid.NewGuid(),
-            Progress = 12,
             Radius = 3,
             Severity = PollutedLocation.SeverityLevel.High
         };
@@ -569,7 +567,6 @@ public class PollutedLocationControllerTests
         var updateRequest = new PollutedLocationUpdateRequest
         {
             Id = Guid.NewGuid(),
-            Progress = 12,
             Radius = 3,
             Severity = PollutedLocation.SeverityLevel.High
         };

--- a/Apsitvarkom.UnitTests/Models/Mapping/CleaningEventMappingTests.cs
+++ b/Apsitvarkom.UnitTests/Models/Mapping/CleaningEventMappingTests.cs
@@ -83,6 +83,33 @@ public class CleaningEventMappingTests
             Assert.That(mappedEvent.StartTime, Is.EqualTo(updateModel.StartTime));
         });
     }
+
+    [Test]
+    public void CleaningEventUpdateRequestToPollutedLocation_NotesNull_NotesSetToNull()
+    {
+        var businessLogicObject = new CleaningEvent
+        {
+            Id = Guid.NewGuid(),
+            PollutedLocationId = Guid.NewGuid(),
+            StartTime = DateTime.Parse("2077-05-12T10:11:12Z"),
+            Notes = "L"
+        };
+
+        var updateModel = new CleaningEventUpdateRequest
+        {
+            Id = businessLogicObject.Id,
+            StartTime = DateTime.Parse("2077-03-12T10:11:12Z"),
+        };
+
+        var mappedEvent = _mapper.Map(updateModel, businessLogicObject);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(mappedEvent.Id, Is.EqualTo(businessLogicObject.Id));
+            Assert.That(mappedEvent.Notes, Is.Null);
+            Assert.That(mappedEvent.StartTime, Is.EqualTo(updateModel.StartTime));
+        });
+    }
     #endregion
 
     #region Response mappings

--- a/Apsitvarkom.UnitTests/Models/Mapping/PollutedLocationMappingTests.cs
+++ b/Apsitvarkom.UnitTests/Models/Mapping/PollutedLocationMappingTests.cs
@@ -112,7 +112,6 @@ public class PollutedLocationMappingTests
             Id = businessLogicObject.Id,
             Radius = 7,
             Severity = PollutedLocation.SeverityLevel.Moderate,
-            Progress = 16,
             Notes = "testt"
         };
 
@@ -127,7 +126,7 @@ public class PollutedLocationMappingTests
             Assert.That(mappedLocation.Spotted, Is.EqualTo(businessLogicObject.Spotted));
             Assert.That(mappedLocation.Id, Is.EqualTo(businessLogicObject.Id));
             Assert.That(mappedLocation.Notes, Is.EqualTo(updateModel.Notes));
-            Assert.That(mappedLocation.Progress, Is.EqualTo(updateModel.Progress));
+            Assert.That(mappedLocation.Progress, Is.EqualTo(businessLogicObject.Progress));
             Assert.That(mappedLocation.Radius, Is.EqualTo(updateModel.Radius));
             Assert.That(mappedLocation.Severity, Is.EqualTo(updateModel.Severity));
         });

--- a/Apsitvarkom.UnitTests/Models/Mapping/PollutedLocationMappingTests.cs
+++ b/Apsitvarkom.UnitTests/Models/Mapping/PollutedLocationMappingTests.cs
@@ -133,7 +133,7 @@ public class PollutedLocationMappingTests
     }
 
     [Test]
-    public void PollutedLocationUpdateRequestToPollutedLocation_SomePropertiesNull_KeepsBusinessObjectValues()
+    public void PollutedLocationUpdateRequestToPollutedLocation_NotesNull_NotesSetToNull()
     {
         var businessLogicObject = new PollutedLocation
         {
@@ -171,7 +171,7 @@ public class PollutedLocationMappingTests
             Assert.That(mappedLocation.Location.Title.Lithuanian, Is.EqualTo(businessLogicObject.Location.Title.Lithuanian));
             Assert.That(mappedLocation.Spotted, Is.EqualTo(businessLogicObject.Spotted));
             Assert.That(mappedLocation.Id, Is.EqualTo(businessLogicObject.Id));
-            Assert.That(mappedLocation.Notes, Is.EqualTo(businessLogicObject.Notes));
+            Assert.That(mappedLocation.Notes, Is.Null);
             Assert.That(mappedLocation.Progress, Is.EqualTo(businessLogicObject.Progress));
             Assert.That(mappedLocation.Radius, Is.EqualTo(updateModel.Radius));
             Assert.That(mappedLocation.Severity, Is.EqualTo(updateModel.Severity));

--- a/Apsitvarkom.UnitTests/Models/Validation/CleaningEventUpdateRequestValidationTests.cs
+++ b/Apsitvarkom.UnitTests/Models/Validation/CleaningEventUpdateRequestValidationTests.cs
@@ -31,6 +31,12 @@ public class CleaningEventUpdateRequestValidationTests
         },
         new()
         { 
+            // Missing StartTime
+            Id = Guid.NewGuid(),
+            Notes = "boop"
+        },
+        new()
+        { 
             // Invalid StartTime
             Id = Guid.NewGuid(),
             StartTime = DateTime.Parse("2007-03-12T10:11:12Z"),

--- a/Apsitvarkom.UnitTests/Models/Validation/PollutedLocationUpdateRequestValidationTests.cs
+++ b/Apsitvarkom.UnitTests/Models/Validation/PollutedLocationUpdateRequestValidationTests.cs
@@ -34,6 +34,18 @@ public class PollutedLocationUpdateRequestValidatorTests
             Severity = PollutedLocation.SeverityLevel.High,
         },
         new()
+        {
+            // Missing radius
+            Id = Guid.NewGuid(),
+            Severity = PollutedLocation.SeverityLevel.Low,
+        },
+        new()
+        {
+            // Missing severity
+            Id = Guid.NewGuid(),
+            Radius = 1,
+        },
+        new()
         { 
             // Invalid radius
             Id = Guid.NewGuid(),

--- a/Apsitvarkom.UnitTests/Models/Validation/PollutedLocationUpdateRequestValidationTests.cs
+++ b/Apsitvarkom.UnitTests/Models/Validation/PollutedLocationUpdateRequestValidationTests.cs
@@ -15,7 +15,6 @@ public class PollutedLocationUpdateRequestValidatorTests
             Id = Guid.NewGuid(),
             Radius = 5,
             Severity = PollutedLocation.SeverityLevel.Moderate,
-            Progress = 41,
             Notes = "Prisoners test."
         },
         new()
@@ -23,7 +22,6 @@ public class PollutedLocationUpdateRequestValidatorTests
             Id = Guid.NewGuid(),
             Radius = 12,
             Severity = PollutedLocation.SeverityLevel.Low,
-            Progress = 13,
         },
     };
 
@@ -32,23 +30,13 @@ public class PollutedLocationUpdateRequestValidatorTests
         new()
         {
              // Missing id
-            Progress = 1,
             Radius = 1,
             Severity = PollutedLocation.SeverityLevel.High,
         },
         new()
         { 
-            // Invalid progress
-            Id = Guid.NewGuid(),
-            Progress = 101,
-            Radius = 2,
-            Severity = PollutedLocation.SeverityLevel.Low,
-        },
-        new()
-        { 
             // Invalid radius
             Id = Guid.NewGuid(),
-            Progress = 11,
             Radius = 0,
             Severity = PollutedLocation.SeverityLevel.Low,
         },


### PR DESCRIPTION
## What was done

<!-- Describe in points what was done for easier overview -->

- Fixed an issue where we've previously had no way to set `Notes` property to null by using `Patch`.
- Additionally removed progress from PollutedLocationUpdateRequest, as this will have a separate endpoint dedicated to it.

<!-- If needed, describe your changes in detail here -->
