### PR TITLE
Extra validation measures, CleaningEvent adjustments

### DIFF
--- a/Apsitvarkom.Api/Apsitvarkom.Api.csproj
+++ b/Apsitvarkom.Api/Apsitvarkom.Api.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Apsitvarkom.Configuration\Apsitvarkom.Configuration.csproj" />
     <ProjectReference Include="..\Apsitvarkom.DataAccess\Apsitvarkom.DataAccess.csproj" />
+    <ProjectReference Include="..\Apsitvarkom.ModelActions\Apsitvarkom.ModelActions.csproj" />
     <ProjectReference Include="..\Apsitvarkom.Models\Apsitvarkom.Models.csproj" />
   </ItemGroup>
 

--- a/Apsitvarkom.Api/Controllers/CleaningEventController.cs
+++ b/Apsitvarkom.Api/Controllers/CleaningEventController.cs
@@ -134,7 +134,7 @@ public class CleaningEventController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(List<string>))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [HttpPatch("Update")]
+    [HttpPut("Update")]
     public async Task<ActionResult<CleaningEventResponse>> Update(CleaningEventUpdateRequest cleaningEventUpdateRequest)
     {
         var validationResult = await _cleaningEventUpdateValidator.ValidateAsync(cleaningEventUpdateRequest);

--- a/Apsitvarkom.Api/Controllers/PollutedLocationController.cs
+++ b/Apsitvarkom.Api/Controllers/PollutedLocationController.cs
@@ -163,7 +163,7 @@ public class PollutedLocationController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(List<string>))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    [HttpPatch("Update")]
+    [HttpPut("Update")]
     public async Task<ActionResult<PollutedLocationResponse>> Update(PollutedLocationUpdateRequest pollutedLocationUpdateRequest)
     {
         var validationResult = await _pollutedLocationUpdateValidator.ValidateAsync(pollutedLocationUpdateRequest);

--- a/Apsitvarkom.Api/Middleware/LogRequestStatisticsMiddleware.cs
+++ b/Apsitvarkom.Api/Middleware/LogRequestStatisticsMiddleware.cs
@@ -1,0 +1,34 @@
+﻿using System.Diagnostics;
+
+namespace Apsitvarkom.Api.Middleware
+{
+    public class LogRequestStatisticsMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private int _currentRequest = 0;
+
+        public LogRequestStatisticsMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            var requestId = Interlocked.Increment(ref _currentRequest);
+            var sw = Stopwatch.StartNew();
+            Console.WriteLine($"[{requestId}] [{context.Request.Method}] Request URL: {Microsoft.AspNetCore.Http.Extensions.UriHelper.GetDisplayUrl(context.Request)}");
+
+            await _next(context);
+
+            Console.WriteLine($"[{requestId}] Finished with status code {context.Response.StatusCode}. The request took {sw.ElapsedMilliseconds} ms.");
+        }
+    }
+
+    public static class LogRequestStatisticsMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseLogRequestStatistics(this IApplicationBuilder app)
+        {
+            return app.UseMiddleware<LogRequestStatisticsMiddleware>();
+        }
+    }
+}

--- a/Apsitvarkom.Api/Program.cs
+++ b/Apsitvarkom.Api/Program.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Serialization;
 using Apsitvarkom.ModelActions.Mapping;
 using Apsitvarkom.ModelActions.Validation;
 using Apsitvarkom.Models;
+using Apsitvarkom.Api.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -64,6 +65,7 @@ var app = builder.Build();
 
 if (app.Environment.IsDevelopment() || app.Environment.IsStaging())
 {
+    app.UseLogRequestStatistics();
     app.UseSwagger();
     app.UseSwaggerUI();
 

--- a/Apsitvarkom.Api/Program.cs
+++ b/Apsitvarkom.Api/Program.cs
@@ -1,12 +1,12 @@
 using Apsitvarkom.Configuration;
 using Apsitvarkom.DataAccess;
-using Apsitvarkom.Models.Mapping;
-using Apsitvarkom.Models.Public;
 using FluentValidation;
 using MicroElements.Swashbuckle.FluentValidation.AspNetCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 using System.Text.Json.Serialization;
+using Apsitvarkom.ModelActions.Mapping;
+using Apsitvarkom.ModelActions.Validation;
 using Apsitvarkom.Models;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/Apsitvarkom.DataAccess/DbInitializer.cs
+++ b/Apsitvarkom.DataAccess/DbInitializer.cs
@@ -76,7 +76,7 @@ public static class DbInitializer
                 Radius = 21,
                 Severity = PollutedLocation.SeverityLevel.High,
                 Spotted = DateTime.Parse("2023-03-12T23:41:21Z").ToUniversalTime(),
-                Progress = 80,
+                Progress = 100,
                 Events = new List<CleaningEvent>()
             },
             new()
@@ -224,23 +224,22 @@ public static class DbInitializer
             new()
             {
                 Id = Guid.Parse("073d1855-1dba-4ce6-857b-3cfa9f36a1ba"),
-                StartTime = new DateTime(2023, 1, 14, 14, 00, 00).ToUniversalTime(),
+                StartTime = new DateTime(2023, 12, 14, 14, 00, 00).ToUniversalTime(),
                 Notes = "Bring your own trash-bags.",
                 IsFinalized = false
             },
             new()
             {
                 Id = Guid.Parse("8e8bf1df-e732-409e-976a-d61806ee7c19"),
-                StartTime = new DateTime(2023, 1, 20, 15, 30, 00).ToUniversalTime(),
+                StartTime = new DateTime(2023, 11, 20, 15, 30, 00).ToUniversalTime(),
                 IsFinalized = false
-
             },
             new()
             {
                 Id = Guid.Parse("0d9374dc-0d28-4b7c-86bf-4cc36e848604"),
-                StartTime = new DateTime(2022, 12, 20, 16, 00, 00).ToUniversalTime(),
+                StartTime = new DateTime(2022, 10, 20, 16, 00, 00).ToUniversalTime(),
                 Notes = "Apsitvarkom!:)",
-                IsFinalized = false
+                IsFinalized = true
             },
             new()
             {
@@ -253,7 +252,7 @@ public static class DbInitializer
             {
                 Id = Guid.Parse("2931a606-c344-4ffd-8774-0cc07d859902"),
                 StartTime = new DateTime(2022, 11, 11, 11, 11, 11).ToUniversalTime(),
-                IsFinalized = false
+                IsFinalized = true
             },
             new()
             {
@@ -265,7 +264,7 @@ public static class DbInitializer
             {
                 Id = Guid.Parse("ae248785-2121-4717-b6b2-a53947bb1774"),
                 StartTime = new DateTime(2022, 9, 10, 11, 12, 13).ToUniversalTime(),
-                IsFinalized = false
+                IsFinalized = true
             }
         };
     }

--- a/Apsitvarkom.DataAccess/DbInitializer.cs
+++ b/Apsitvarkom.DataAccess/DbInitializer.cs
@@ -98,7 +98,8 @@ public static class DbInitializer
                 Notes = "Apsitvarkom to the moooooon",
                 Events = new List<CleaningEvent>
                 {
-                    FakeCleaningEvents[1]
+                    FakeCleaningEvents[1],
+                    FakeCleaningEvents[7]
                 }
             },
             new()
@@ -201,7 +202,11 @@ public static class DbInitializer
                 Spotted = DateTime.Parse("2022-06-20T11:22:33Z").ToUniversalTime(),
                 Progress = 20,
                 Notes = "The fans made a big mess after the game. Apsitvarkom?",
-                Events = new List<CleaningEvent>()
+                Events = new List<CleaningEvent>
+                {
+                    FakeCleaningEvents[5],
+                    FakeCleaningEvents[6]
+                }
             }
         };
     }
@@ -220,24 +225,47 @@ public static class DbInitializer
             {
                 Id = Guid.Parse("073d1855-1dba-4ce6-857b-3cfa9f36a1ba"),
                 StartTime = new DateTime(2023, 1, 14, 14, 00, 00).ToUniversalTime(),
-                Notes = "Bring your own trash-bags."
+                Notes = "Bring your own trash-bags.",
+                IsFinalized = false
             },
             new()
             {
                 Id = Guid.Parse("8e8bf1df-e732-409e-976a-d61806ee7c19"),
-                StartTime = new DateTime(2023, 1, 20, 15, 30, 00).ToUniversalTime()
+                StartTime = new DateTime(2023, 1, 20, 15, 30, 00).ToUniversalTime(),
+                IsFinalized = false
+
             },
             new()
             {
                 Id = Guid.Parse("0d9374dc-0d28-4b7c-86bf-4cc36e848604"),
                 StartTime = new DateTime(2022, 12, 20, 16, 00, 00).ToUniversalTime(),
-                Notes = "Apsitvarkom!:)"
+                Notes = "Apsitvarkom!:)",
+                IsFinalized = false
             },
             new()
             {
                 Id = Guid.Parse("5638be6e-773c-405d-a7ef-1f76115ae8c5"),
                 StartTime = new DateTime(2022, 12, 12, 12, 12, 12).ToUniversalTime(),
-                Notes = "Let's finish it once and for all."
+                Notes = "Let's finish it once and for all.",
+                IsFinalized = false
+            },
+            new()
+            {
+                Id = Guid.Parse("2931a606-c344-4ffd-8774-0cc07d859902"),
+                StartTime = new DateTime(2022, 11, 11, 11, 11, 11).ToUniversalTime(),
+                IsFinalized = false
+            },
+            new()
+            {
+                Id = Guid.Parse("26f7eb6b-7e74-4b93-9576-7f81c1bd7b2f"),
+                StartTime = new DateTime(2022, 11, 12, 13, 14, 15).ToUniversalTime(),
+                IsFinalized = true
+            },
+            new()
+            {
+                Id = Guid.Parse("ae248785-2121-4717-b6b2-a53947bb1774"),
+                StartTime = new DateTime(2022, 9, 10, 11, 12, 13).ToUniversalTime(),
+                IsFinalized = false
             }
         };
     }

--- a/Apsitvarkom.IntegrationTests/DataAccess/PollutedLocationContextDatabaseTests.cs
+++ b/Apsitvarkom.IntegrationTests/DataAccess/PollutedLocationContextDatabaseTests.cs
@@ -267,7 +267,7 @@ public class PollutedLocationContextDatabaseTests
         var response = (await dbRepository.GetAllAsync()).ToArray();
 
         Assert.That(response.Length, Is.EqualTo(objectIds.Length));
-        Assert.That(response.Select(x => x.Id), Is.EqualTo(objectIds));
+        Assert.That(response.Select(x => x.Id), Is.EquivalentTo(objectIds));
     }
 
     [Test]

--- a/Apsitvarkom.ModelActions/Apsitvarkom.ModelActions.csproj
+++ b/Apsitvarkom.ModelActions/Apsitvarkom.ModelActions.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Apsitvarkom.DataAccess\Apsitvarkom.DataAccess.csproj" />
     <ProjectReference Include="..\Apsitvarkom.Models\Apsitvarkom.Models.csproj" />
   </ItemGroup>
 

--- a/Apsitvarkom.ModelActions/Apsitvarkom.ModelActions.csproj
+++ b/Apsitvarkom.ModelActions/Apsitvarkom.ModelActions.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="12.0.0" />
+    <PackageReference Include="FluentValidation" Version="11.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Apsitvarkom.Models\Apsitvarkom.Models.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Apsitvarkom.ModelActions/Mapping/CleaningEventProfile.cs
+++ b/Apsitvarkom.ModelActions/Mapping/CleaningEventProfile.cs
@@ -31,10 +31,12 @@ public class CleaningEventProfile : Profile
     private void MapResponses()
     {
         CreateMap<CleaningEvent, CleaningEventResponse>()
-            .ForMember(x => x.Status, opt => 
-                opt.MapFrom(x => 
-                    x.IsFinalized ? CleaningEventResponse.State.Finalized : 
-                    x.StartTime > DateTime.UtcNow ? CleaningEventResponse.State.Foreseen : 
-                    CleaningEventResponse.State.Finished));
+            .ForMember(x => x.Status, opt =>
+                opt.MapFrom((cleaningEvent, _) => (cleaningEvent.IsFinalized, cleaningEvent.StartTime) switch
+                {
+                    (true, _) => CleaningEventResponse.State.Finalized,
+                    (false, var startTime) when startTime > DateTime.UtcNow => CleaningEventResponse.State.Foreseen,
+                    _ => CleaningEventResponse.State.Finished
+                }));
     }
 }

--- a/Apsitvarkom.ModelActions/Mapping/CleaningEventProfile.cs
+++ b/Apsitvarkom.ModelActions/Mapping/CleaningEventProfile.cs
@@ -22,11 +22,9 @@ public class CleaningEventProfile : Profile
             .ForMember(x => x.Id, opt => opt.MapFrom(x => x.Id));
         CreateMap<CleaningEventCreateRequest, CleaningEvent>()
             .ForMember(x => x.Id, opt => opt.Ignore())
-            .ForMember(x => x.PollutedLocation, opt => opt.Ignore())
             .ForMember(x => x.IsFinalized, opt => opt.Ignore());
         CreateMap<CleaningEventUpdateRequest, CleaningEvent>()
             .ForMember(x => x.PollutedLocationId, opt => opt.Ignore())
-            .ForMember(x => x.PollutedLocation, opt => opt.Ignore())
             .ForMember(x => x.IsFinalized, opt => opt.Ignore());
     }
 

--- a/Apsitvarkom.ModelActions/Mapping/CleaningEventProfile.cs
+++ b/Apsitvarkom.ModelActions/Mapping/CleaningEventProfile.cs
@@ -1,7 +1,8 @@
-﻿using Apsitvarkom.Models.Public;
+﻿using Apsitvarkom.Models;
+using Apsitvarkom.Models.Public;
 using AutoMapper;
 
-namespace Apsitvarkom.Models.Mapping;
+namespace Apsitvarkom.ModelActions.Mapping;
 
 /// <summary>
 /// Implements a profile for AutoMapper that allows creating maps required for conversion of class

--- a/Apsitvarkom.ModelActions/Mapping/CleaningEventProfile.cs
+++ b/Apsitvarkom.ModelActions/Mapping/CleaningEventProfile.cs
@@ -32,8 +32,9 @@ public class CleaningEventProfile : Profile
     {
         CreateMap<CleaningEvent, CleaningEventResponse>()
             .ForMember(x => x.Status, opt => 
-                opt.MapFrom(x => x.IsFinalized ? CleaningEventResponse.State.Finalized 
-                                                                        : x.StartTime > DateTime.UtcNow ? CleaningEventResponse.State.Foreseen 
-                                                                                                        : CleaningEventResponse.State.Finished));
+                opt.MapFrom(x => 
+                    x.IsFinalized ? CleaningEventResponse.State.Finalized : 
+                    x.StartTime > DateTime.UtcNow ? CleaningEventResponse.State.Foreseen : 
+                    CleaningEventResponse.State.Finished));
     }
 }

--- a/Apsitvarkom.ModelActions/Mapping/CleaningEventProfile.cs
+++ b/Apsitvarkom.ModelActions/Mapping/CleaningEventProfile.cs
@@ -22,14 +22,20 @@ public class CleaningEventProfile : Profile
             .ForMember(x => x.Id, opt => opt.MapFrom(x => x.Id));
         CreateMap<CleaningEventCreateRequest, CleaningEvent>()
             .ForMember(x => x.Id, opt => opt.Ignore())
-            .ForMember(x => x.PollutedLocation, opt => opt.Ignore());
+            .ForMember(x => x.PollutedLocation, opt => opt.Ignore())
+            .ForMember(x => x.IsFinalized, opt => opt.Ignore());
         CreateMap<CleaningEventUpdateRequest, CleaningEvent>()
             .ForMember(x => x.PollutedLocationId, opt => opt.Ignore())
-            .ForMember(x => x.PollutedLocation, opt => opt.Ignore());
+            .ForMember(x => x.PollutedLocation, opt => opt.Ignore())
+            .ForMember(x => x.IsFinalized, opt => opt.Ignore());
     }
 
     private void MapResponses()
     {
-        CreateMap<CleaningEvent, CleaningEventResponse>();
+        CreateMap<CleaningEvent, CleaningEventResponse>()
+            .ForMember(x => x.Status, opt => 
+                opt.MapFrom(x => x.IsFinalized ? CleaningEventResponse.State.Finalized 
+                                                                        : x.StartTime > DateTime.UtcNow ? CleaningEventResponse.State.Foreseen 
+                                                                                                        : CleaningEventResponse.State.Finished));
     }
 }

--- a/Apsitvarkom.ModelActions/Mapping/PollutedLocationProfile.cs
+++ b/Apsitvarkom.ModelActions/Mapping/PollutedLocationProfile.cs
@@ -1,7 +1,8 @@
-﻿using Apsitvarkom.Models.Public;
+﻿using Apsitvarkom.Models;
+using Apsitvarkom.Models.Public;
 using AutoMapper;
 
-namespace Apsitvarkom.Models.Mapping;
+namespace Apsitvarkom.ModelActions.Mapping;
 
 /// <summary>
 /// Implements a profile for AutoMapper that allows creating maps required for conversion of class

--- a/Apsitvarkom.ModelActions/Validation/CleaningEventCreateRequestValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/CleaningEventCreateRequestValidator.cs
@@ -32,7 +32,7 @@ public class CleaningEventCreateRequestValidator : AbstractValidator<CleaningEve
                     return true;
 
                 if (pollutedLocation.Progress == 100)
-                    context.AddFailure("No more events for this polluted location can be created, as it is already tidied up.");
+                    context.AddFailure("No more events for this polluted location can be created, as it is already cleaned up.");
 
                 if (pollutedLocation.Events.Any(x => !x.IsFinalized))
                     context.AddFailure("One active cleaning event for this polluted location already exists.");

--- a/Apsitvarkom.ModelActions/Validation/CleaningEventCreateRequestValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/CleaningEventCreateRequestValidator.cs
@@ -1,0 +1,13 @@
+﻿using Apsitvarkom.Models.Public;
+using FluentValidation;
+
+namespace Apsitvarkom.ModelActions.Validation;
+
+public class CleaningEventCreateRequestValidator : AbstractValidator<CleaningEventCreateRequest>
+{
+    public CleaningEventCreateRequestValidator()
+    {
+        RuleFor(l => l.StartTime).NotNull().GreaterThan(DateTime.UtcNow);
+        RuleFor(l => l.PollutedLocationId).NotNull();
+    }
+}

--- a/Apsitvarkom.ModelActions/Validation/CleaningEventCreateRequestValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/CleaningEventCreateRequestValidator.cs
@@ -1,13 +1,39 @@
-﻿using Apsitvarkom.Models.Public;
+﻿using Apsitvarkom.DataAccess;
+using Apsitvarkom.Models;
+using Apsitvarkom.Models.Public;
 using FluentValidation;
 
 namespace Apsitvarkom.ModelActions.Validation;
 
 public class CleaningEventCreateRequestValidator : AbstractValidator<CleaningEventCreateRequest>
 {
-    public CleaningEventCreateRequestValidator()
+    private readonly IRepository<CleaningEvent> _cleaningEventRepository;
+
+    public CleaningEventCreateRequestValidator(IRepository<CleaningEvent> cleaningEventRepository)
     {
+        _cleaningEventRepository = cleaningEventRepository;
+
         RuleFor(l => l.StartTime).NotNull().GreaterThan(DateTime.UtcNow);
-        RuleFor(l => l.PollutedLocationId).NotNull();
+        RuleFor(l => l.PollutedLocationId).NotNull().DependentRules(() =>
+        {
+            RuleFor(l => l.PollutedLocationId).MustAsync(async (req, _, context, _) =>
+            {
+                bool cleaningEventExists;
+                try
+                {
+                    cleaningEventExists = await _cleaningEventRepository.ExistsByPropertyAsync(x => x.PollutedLocationId == req.PollutedLocationId && x.IsFinalized != true);
+                }
+                catch (Exception)
+                {
+                    return true;
+                }
+
+                if (cleaningEventExists is false)
+                    return true;
+
+                context.AddFailure("One active cleaning event for this polluted location already exists.");
+                return true;
+            });
+        });
     }
 }

--- a/Apsitvarkom.ModelActions/Validation/CleaningEventFinalizeRequestValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/CleaningEventFinalizeRequestValidator.cs
@@ -42,7 +42,7 @@ public class CleaningEventFinalizeRequestValidator : AbstractValidator<CleaningE
                 if (cleaningEvent.StartTime > DateTime.UtcNow)
                     context.AddFailure("The requested cleaning event hasn't yet happened.");
 
-                if (req.NewProgress is not null && pollutedLocation.Progress > req.NewProgress)
+                if (req.NewProgress is not null && req.NewProgress >= 0 && pollutedLocation.Progress > req.NewProgress)
                     context.AddFailure($"New progress value cannot be lower than the current ({pollutedLocation.Progress}).");
 
                 return true;

--- a/Apsitvarkom.ModelActions/Validation/CleaningEventFinalizeRequestValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/CleaningEventFinalizeRequestValidator.cs
@@ -42,7 +42,7 @@ public class CleaningEventFinalizeRequestValidator : AbstractValidator<CleaningE
                 if (cleaningEvent.StartTime > DateTime.UtcNow)
                     context.AddFailure("The requested cleaning event hasn't yet happened.");
 
-                if (pollutedLocation.Progress > req.NewProgress)
+                if (req.NewProgress is not null && pollutedLocation.Progress > req.NewProgress)
                     context.AddFailure($"New progress value cannot be lower than the current ({pollutedLocation.Progress}).");
 
                 return true;

--- a/Apsitvarkom.ModelActions/Validation/CleaningEventFinalizeRequestValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/CleaningEventFinalizeRequestValidator.cs
@@ -1,0 +1,52 @@
+﻿using Apsitvarkom.DataAccess;
+using Apsitvarkom.Models;
+using Apsitvarkom.Models.Public;
+using FluentValidation;
+
+namespace Apsitvarkom.ModelActions.Validation;
+
+public class CleaningEventFinalizeRequestValidator : AbstractValidator<CleaningEventFinalizeRequest>
+{
+    private readonly IPollutedLocationRepository _pollutedLocationRepository;
+
+    public CleaningEventFinalizeRequestValidator(IPollutedLocationRepository pollutedLocationRepository)
+    {
+        _pollutedLocationRepository = pollutedLocationRepository;
+
+        RuleFor(l => l.NewProgress).NotNull().InclusiveBetween(0, 100);
+        RuleFor(l => l.Id).NotNull().DependentRules(() =>
+        {
+            RuleFor(l => l.Id).MustAsync(async (req, _, context, _) =>
+            {
+                PollutedLocation? pollutedLocation;
+                try
+                {
+                    pollutedLocation = await _pollutedLocationRepository.GetByPropertyAsync(x => x.Events.Any(e => e.Id == req.Id));
+                }
+                catch (Exception)
+                {
+                    return true;
+                }
+
+                if (pollutedLocation is null)
+                    return true;
+
+                var cleaningEvent = pollutedLocation.Events.Single(x => x.Id == req.Id);
+
+                if (cleaningEvent.IsFinalized)
+                {
+                    context.AddFailure("The cleaning event is already finalized.");
+                    return true;
+                }
+
+                if (cleaningEvent.StartTime > DateTime.UtcNow)
+                    context.AddFailure("The requested cleaning event hasn't yet happened.");
+
+                if (pollutedLocation.Progress > req.NewProgress)
+                    context.AddFailure($"New progress value cannot be lower than the current ({pollutedLocation.Progress}).");
+
+                return true;
+            });
+        });
+    }
+}

--- a/Apsitvarkom.ModelActions/Validation/CleaningEventUpdateRequestValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/CleaningEventUpdateRequestValidator.cs
@@ -1,13 +1,41 @@
-﻿using Apsitvarkom.Models.Public;
+﻿using Apsitvarkom.DataAccess;
+using Apsitvarkom.Models;
+using Apsitvarkom.Models.Public;
 using FluentValidation;
 
 namespace Apsitvarkom.ModelActions.Validation;
 
 public class CleaningEventUpdateRequestValidator : AbstractValidator<CleaningEventUpdateRequest>
 {
-    public CleaningEventUpdateRequestValidator()
+    private readonly IRepository<CleaningEvent> _cleaningEventRepository;
+
+    public CleaningEventUpdateRequestValidator(IRepository<CleaningEvent> cleaningEventRepository)
     {
-        RuleFor(l => l.Id).NotNull();
+        _cleaningEventRepository = cleaningEventRepository;
+
         RuleFor(l => l.StartTime).NotNull().GreaterThan(DateTime.UtcNow);
+        RuleFor(l => l.Id).NotNull().DependentRules(() =>
+        {
+            RuleFor(l => l.Id).MustAsync(async (req, _, context, _) =>
+            {
+                CleaningEvent? cleaningEvent;
+                try
+                {
+                    cleaningEvent = await _cleaningEventRepository.GetByPropertyAsync(x => x.Id == req.Id);
+                }
+                catch (Exception)
+                {
+                    return true;
+                }
+
+                if (cleaningEvent is null)
+                    return true;
+
+                if (cleaningEvent.IsFinalized)
+                    context.AddFailure("The cleaning event is already finalized.");
+
+                return true;
+            });
+        });
     }
 }

--- a/Apsitvarkom.ModelActions/Validation/CleaningEventUpdateRequestValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/CleaningEventUpdateRequestValidator.cs
@@ -1,0 +1,13 @@
+﻿using Apsitvarkom.Models.Public;
+using FluentValidation;
+
+namespace Apsitvarkom.ModelActions.Validation;
+
+public class CleaningEventUpdateRequestValidator : AbstractValidator<CleaningEventUpdateRequest>
+{
+    public CleaningEventUpdateRequestValidator()
+    {
+        RuleFor(l => l.Id).NotNull();
+        RuleFor(l => l.StartTime).NotNull().GreaterThan(DateTime.UtcNow);
+    }
+}

--- a/Apsitvarkom.ModelActions/Validation/CoordinatesCreateRequestValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/CoordinatesCreateRequestValidator.cs
@@ -1,0 +1,13 @@
+﻿using Apsitvarkom.Models.Public;
+using FluentValidation;
+
+namespace Apsitvarkom.ModelActions.Validation;
+
+public class CoordinatesCreateRequestValidator : AbstractValidator<CoordinatesCreateRequest>
+{
+    public CoordinatesCreateRequestValidator()
+    {
+        RuleFor(coordinates => coordinates.Latitude).NotNull().InclusiveBetween(-90.0, 90.0);
+        RuleFor(coordinates => coordinates.Longitude).NotNull().InclusiveBetween(-180.0, 180.0);
+    }
+}

--- a/Apsitvarkom.ModelActions/Validation/CoordinatesResponseValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/CoordinatesResponseValidator.cs
@@ -1,0 +1,13 @@
+﻿using Apsitvarkom.Models.Public;
+using FluentValidation;
+
+namespace Apsitvarkom.ModelActions.Validation;
+
+public class CoordinatesResponseValidator : AbstractValidator<CoordinatesResponse>
+{
+    public CoordinatesResponseValidator()
+    {
+        RuleFor(coordinates => coordinates.Latitude).InclusiveBetween(-90.0, 90.0);
+        RuleFor(coordinates => coordinates.Longitude).InclusiveBetween(-180.0, 180.0);
+    }
+}

--- a/Apsitvarkom.ModelActions/Validation/LocationCreateRequestValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/LocationCreateRequestValidator.cs
@@ -1,0 +1,13 @@
+﻿using Apsitvarkom.Models.Public;
+using FluentValidation;
+
+namespace Apsitvarkom.ModelActions.Validation;
+
+public class LocationCreateRequestValidator : AbstractValidator<LocationCreateRequest>
+{
+    public LocationCreateRequestValidator(IValidator<CoordinatesCreateRequest> coordinatesCreateRequestValidator)
+    {
+        RuleFor(l => l.Coordinates).NotNull();
+        RuleFor(l => l.Coordinates!).SetValidator(coordinatesCreateRequestValidator).When(l => l.Coordinates is not null);
+    }
+}

--- a/Apsitvarkom.ModelActions/Validation/LocationCreateRequestValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/LocationCreateRequestValidator.cs
@@ -7,7 +7,9 @@ public class LocationCreateRequestValidator : AbstractValidator<LocationCreateRe
 {
     public LocationCreateRequestValidator(IValidator<CoordinatesCreateRequest> coordinatesCreateRequestValidator)
     {
-        RuleFor(l => l.Coordinates).NotNull();
-        RuleFor(l => l.Coordinates!).SetValidator(coordinatesCreateRequestValidator).When(l => l.Coordinates is not null);
+        RuleFor(l => l.Coordinates).NotNull().DependentRules(() =>
+        {
+            RuleFor(l => l.Coordinates!).SetValidator(coordinatesCreateRequestValidator);
+        });
     }
 }

--- a/Apsitvarkom.ModelActions/Validation/LocationResponseValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/LocationResponseValidator.cs
@@ -1,0 +1,13 @@
+﻿using Apsitvarkom.Models.Public;
+using FluentValidation;
+
+namespace Apsitvarkom.ModelActions.Validation;
+
+public class LocationResponseValidator : AbstractValidator<LocationResponse>
+{
+    public LocationResponseValidator(IValidator<CoordinatesResponse> coordinatesResponseValidator, IValidator<TranslatedResponse<string>> translatedResponseStringValidator)
+    {
+        RuleFor(location => location.Coordinates).SetValidator(coordinatesResponseValidator);
+        RuleFor(location => location.Title).SetValidator(translatedResponseStringValidator);
+    }
+}

--- a/Apsitvarkom.ModelActions/Validation/ObjectIdentifyRequestValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/ObjectIdentifyRequestValidator.cs
@@ -1,0 +1,12 @@
+﻿using Apsitvarkom.Models.Public;
+using FluentValidation;
+
+namespace Apsitvarkom.ModelActions.Validation;
+
+public class ObjectIdentifyRequestValidator : AbstractValidator<ObjectIdentifyRequest>
+{
+    public ObjectIdentifyRequestValidator()
+    {
+        RuleFor(l => l.Id).NotNull();
+    }
+}

--- a/Apsitvarkom.ModelActions/Validation/PollutedLocationCreateRequestValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/PollutedLocationCreateRequestValidator.cs
@@ -9,8 +9,9 @@ public class PollutedLocationCreateRequestValidator : AbstractValidator<Polluted
     {
         RuleFor(l => l.Radius).NotNull().GreaterThanOrEqualTo(1);
         RuleFor(l => l.Severity).NotNull();
-
-        RuleFor(l => l.Location).NotNull();
-        RuleFor(l => l.Location!).SetValidator(locationCreateRequestValidator).When(l => l.Location is not null);
+        RuleFor(l => l.Location).NotNull().DependentRules(() =>
+        {
+            RuleFor(l => l.Location!).SetValidator(locationCreateRequestValidator);
+        });
     }
 }

--- a/Apsitvarkom.ModelActions/Validation/PollutedLocationCreateRequestValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/PollutedLocationCreateRequestValidator.cs
@@ -1,0 +1,16 @@
+﻿using Apsitvarkom.Models.Public;
+using FluentValidation;
+
+namespace Apsitvarkom.ModelActions.Validation;
+
+public class PollutedLocationCreateRequestValidator : AbstractValidator<PollutedLocationCreateRequest>
+{
+    public PollutedLocationCreateRequestValidator(IValidator<LocationCreateRequest> locationCreateRequestValidator)
+    {
+        RuleFor(l => l.Radius).NotNull().GreaterThanOrEqualTo(1);
+        RuleFor(l => l.Severity).NotNull();
+
+        RuleFor(l => l.Location).NotNull();
+        RuleFor(l => l.Location!).SetValidator(locationCreateRequestValidator).When(l => l.Location is not null);
+    }
+}

--- a/Apsitvarkom.ModelActions/Validation/PollutedLocationResponseValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/PollutedLocationResponseValidator.cs
@@ -1,0 +1,15 @@
+﻿using Apsitvarkom.Models.Public;
+using FluentValidation;
+
+namespace Apsitvarkom.ModelActions.Validation;
+
+public class PollutedLocationResponseValidator : AbstractValidator<PollutedLocationResponse>
+{
+    public PollutedLocationResponseValidator(IValidator<LocationResponse> locationResponseValidator)
+    {
+        RuleFor(l => l.Location).SetValidator(locationResponseValidator);
+
+        RuleFor(l => l.Radius).GreaterThanOrEqualTo(1);
+        RuleFor(l => l.Progress).InclusiveBetween(0, 100);
+    }
+}

--- a/Apsitvarkom.ModelActions/Validation/PollutedLocationResponseValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/PollutedLocationResponseValidator.cs
@@ -8,7 +8,6 @@ public class PollutedLocationResponseValidator : AbstractValidator<PollutedLocat
     public PollutedLocationResponseValidator(IValidator<LocationResponse> locationResponseValidator)
     {
         RuleFor(l => l.Location).SetValidator(locationResponseValidator);
-
         RuleFor(l => l.Radius).GreaterThanOrEqualTo(1);
         RuleFor(l => l.Progress).InclusiveBetween(0, 100);
     }

--- a/Apsitvarkom.ModelActions/Validation/PollutedLocationUpdateRequestValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/PollutedLocationUpdateRequestValidator.cs
@@ -33,7 +33,7 @@ public class PollutedLocationUpdateRequestValidator : AbstractValidator<Polluted
                     return true;
 
                 if (pollutedLocation.Progress == 100)
-                    context.AddFailure("The polluted location is already tidied up.");
+                    context.AddFailure("The polluted location is already cleaned up.");
 
                 return true;
             });

--- a/Apsitvarkom.ModelActions/Validation/PollutedLocationUpdateRequestValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/PollutedLocationUpdateRequestValidator.cs
@@ -1,0 +1,14 @@
+﻿using Apsitvarkom.Models.Public;
+using FluentValidation;
+
+namespace Apsitvarkom.ModelActions.Validation;
+
+public class PollutedLocationUpdateRequestValidator : AbstractValidator<PollutedLocationUpdateRequest>
+{
+    public PollutedLocationUpdateRequestValidator()
+    {
+        RuleFor(l => l.Id).NotNull();
+        RuleFor(l => l.Radius).NotNull().GreaterThanOrEqualTo(1);
+        RuleFor(l => l.Severity).NotNull();
+    }
+}

--- a/Apsitvarkom.ModelActions/Validation/PollutedLocationUpdateRequestValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/PollutedLocationUpdateRequestValidator.cs
@@ -1,14 +1,42 @@
-﻿using Apsitvarkom.Models.Public;
+﻿using Apsitvarkom.DataAccess;
+using Apsitvarkom.Models;
+using Apsitvarkom.Models.Public;
 using FluentValidation;
 
 namespace Apsitvarkom.ModelActions.Validation;
 
 public class PollutedLocationUpdateRequestValidator : AbstractValidator<PollutedLocationUpdateRequest>
 {
-    public PollutedLocationUpdateRequestValidator()
+    private readonly IPollutedLocationRepository _pollutedLocationRepository;
+
+    public PollutedLocationUpdateRequestValidator(IPollutedLocationRepository pollutedLocationRepository)
     {
-        RuleFor(l => l.Id).NotNull();
+        _pollutedLocationRepository = pollutedLocationRepository;
+
         RuleFor(l => l.Radius).NotNull().GreaterThanOrEqualTo(1);
         RuleFor(l => l.Severity).NotNull();
+        RuleFor(l => l.Id).NotNull().DependentRules(() =>
+        {
+            RuleFor(l => l.Id).MustAsync(async (req, _, context, _) =>
+            {
+                PollutedLocation? pollutedLocation;
+                try
+                {
+                    pollutedLocation = await _pollutedLocationRepository.GetByPropertyAsync(x => x.Id == req.Id);
+                }
+                catch (Exception)
+                {
+                    return true;
+                }
+
+                if (pollutedLocation is null)
+                    return true;
+
+                if (pollutedLocation.Progress == 100)
+                    context.AddFailure("The polluted location is already tidied up.");
+
+                return true;
+            });
+        });
     }
 }

--- a/Apsitvarkom.ModelActions/Validation/TranslatedResponseStringValidator.cs
+++ b/Apsitvarkom.ModelActions/Validation/TranslatedResponseStringValidator.cs
@@ -1,0 +1,13 @@
+﻿using Apsitvarkom.Models.Public;
+using FluentValidation;
+
+namespace Apsitvarkom.ModelActions.Validation;
+
+public class TranslatedResponseStringValidator : AbstractValidator<TranslatedResponse<string>>
+{
+    public TranslatedResponseStringValidator()
+    {
+        RuleFor(l => l.En).NotNull();
+        RuleFor(l => l.Lt).NotNull();
+    }
+}

--- a/Apsitvarkom.Models/Apsitvarkom.Models.csproj
+++ b/Apsitvarkom.Models/Apsitvarkom.Models.csproj
@@ -6,9 +6,4 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="12.0.0" />
-    <PackageReference Include="FluentValidation" Version="11.2.2" />
-  </ItemGroup>
-
 </Project>

--- a/Apsitvarkom.Models/CleaningEvent.cs
+++ b/Apsitvarkom.Models/CleaningEvent.cs
@@ -17,6 +17,9 @@ public class CleaningEvent
     /// <summary>Additional information about the event.</summary>
     public string? Notes { get; set; }
 
+    /// <summary>Specifies whether the results for the event have already been submitted.</summary>
+    public bool IsFinalized { get; set; }
+
     /// <summary><see cref="Models.PollutedLocation" /> linked to the event.</summary>
     /// <remarks>Meant only for Entity Framework relationships to be created.</remarks>
     public PollutedLocation PollutedLocation { get; set; } = null!;

--- a/Apsitvarkom.Models/CleaningEvent.cs
+++ b/Apsitvarkom.Models/CleaningEvent.cs
@@ -19,8 +19,4 @@ public class CleaningEvent
 
     /// <summary>Specifies whether the results for the event have already been submitted.</summary>
     public bool IsFinalized { get; set; }
-
-    /// <summary><see cref="Models.PollutedLocation" /> linked to the event.</summary>
-    /// <remarks>Meant only for Entity Framework relationships to be created.</remarks>
-    public PollutedLocation PollutedLocation { get; set; } = null!;
 }

--- a/Apsitvarkom.Models/Mapping/CleaningEventProfile.cs
+++ b/Apsitvarkom.Models/Mapping/CleaningEventProfile.cs
@@ -23,8 +23,6 @@ public class CleaningEventProfile : Profile
             .ForMember(x => x.Id, opt => opt.Ignore())
             .ForMember(x => x.PollutedLocation, opt => opt.Ignore());
         CreateMap<CleaningEventUpdateRequest, CleaningEvent>()
-            .ForMember(x => x.StartTime, opt => opt.PreCondition(src => src.StartTime is not null))
-            .ForMember(x => x.Notes, opt => opt.PreCondition(src => src.Notes is not null))
             .ForMember(x => x.PollutedLocationId, opt => opt.Ignore())
             .ForMember(x => x.PollutedLocation, opt => opt.Ignore());
     }

--- a/Apsitvarkom.Models/Mapping/PollutedLocationProfile.cs
+++ b/Apsitvarkom.Models/Mapping/PollutedLocationProfile.cs
@@ -27,14 +27,11 @@ public class PollutedLocationProfile : Profile
             .ForMember(x => x.Events, opt => opt.Ignore());
         CreateMap<ObjectIdentifyRequest, PollutedLocation>(MemberList.None)
             .ForMember(x => x.Id, opt => opt.MapFrom(x => x.Id));
-        CreateMap<PollutedLocationUpdateRequest, PollutedLocation>()
-            .ForMember(x => x.Spotted, opt => opt.Ignore())
-            .ForMember(x => x.Location, opt => opt.Ignore())
-            .ForMember(x => x.Events, opt => opt.Ignore())
-            .ForMember(x => x.Progress, opt => opt.Ignore())
-            .ForMember(x => x.Radius, opt => opt.PreCondition(src => src.Radius is not null))
-            .ForMember(x => x.Severity, opt => opt.PreCondition(src => src.Severity is not null))
-            .ForMember(x => x.Notes, opt => opt.PreCondition(src => src.Notes is not null));
+        CreateMap<PollutedLocationUpdateRequest, PollutedLocation>(MemberList.None)
+            .ForMember(x => x.Id, opt => opt.MapFrom(x => x.Id))
+            .ForMember(x => x.Radius, opt => opt.MapFrom(x => x.Radius))
+            .ForMember(x => x.Severity, opt => opt.MapFrom(x => x.Severity))
+            .ForMember(x => x.Notes, opt => opt.MapFrom(x => x.Notes));
     }
 
     private void MapResponses()

--- a/Apsitvarkom.Models/Mapping/PollutedLocationProfile.cs
+++ b/Apsitvarkom.Models/Mapping/PollutedLocationProfile.cs
@@ -31,7 +31,7 @@ public class PollutedLocationProfile : Profile
             .ForMember(x => x.Spotted, opt => opt.Ignore())
             .ForMember(x => x.Location, opt => opt.Ignore())
             .ForMember(x => x.Events, opt => opt.Ignore())
-            .ForMember(x => x.Progress, opt => opt.PreCondition(src => src.Progress is not null))
+            .ForMember(x => x.Progress, opt => opt.Ignore())
             .ForMember(x => x.Radius, opt => opt.PreCondition(src => src.Radius is not null))
             .ForMember(x => x.Severity, opt => opt.PreCondition(src => src.Severity is not null))
             .ForMember(x => x.Notes, opt => opt.PreCondition(src => src.Notes is not null));

--- a/Apsitvarkom.Models/Public/CleaningEventCreateRequest.cs
+++ b/Apsitvarkom.Models/Public/CleaningEventCreateRequest.cs
@@ -1,6 +1,4 @@
-﻿using FluentValidation;
-
-namespace Apsitvarkom.Models.Public;
+﻿namespace Apsitvarkom.Models.Public;
 
 public class CleaningEventCreateRequest
 {
@@ -9,13 +7,4 @@ public class CleaningEventCreateRequest
     public DateTime? StartTime { get; set; }
 
     public string? Notes { get; set; }
-}
-
-public class CleaningEventCreateRequestValidator : AbstractValidator<CleaningEventCreateRequest>
-{
-    public CleaningEventCreateRequestValidator()
-    {
-        RuleFor(l => l.StartTime).NotNull().GreaterThan(DateTime.UtcNow);
-        RuleFor(l => l.PollutedLocationId).NotNull();
-    }
 }

--- a/Apsitvarkom.Models/Public/CleaningEventFinalizeRequest.cs
+++ b/Apsitvarkom.Models/Public/CleaningEventFinalizeRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace Apsitvarkom.Models.Public;
+
+public class CleaningEventFinalizeRequest
+{
+    public Guid? Id { get; set; }
+
+    public int? NewProgress { get; set; }
+}

--- a/Apsitvarkom.Models/Public/CleaningEventResponse.cs
+++ b/Apsitvarkom.Models/Public/CleaningEventResponse.cs
@@ -9,4 +9,13 @@ public class CleaningEventResponse
     public DateTime StartTime { get; set; }
 
     public string? Notes { get; set; }
+
+    public State Status { get; set; }
+
+    public enum State
+    {
+        Foreseen,
+        Finished,
+        Finalized
+    }
 }

--- a/Apsitvarkom.Models/Public/CleaningEventUpdateRequest.cs
+++ b/Apsitvarkom.Models/Public/CleaningEventUpdateRequest.cs
@@ -1,6 +1,4 @@
-﻿using FluentValidation;
-
-namespace Apsitvarkom.Models.Public;
+﻿namespace Apsitvarkom.Models.Public;
 
 public class CleaningEventUpdateRequest
 {
@@ -9,13 +7,4 @@ public class CleaningEventUpdateRequest
     public DateTime? StartTime { get; set; }
 
     public string? Notes { get; set; }
-}
-
-public class CleaningEventUpdateRequestValidator : AbstractValidator<CleaningEventUpdateRequest>
-{
-    public CleaningEventUpdateRequestValidator()
-    {
-        RuleFor(l => l.Id).NotNull();
-        RuleFor(l => l.StartTime).NotNull().GreaterThan(DateTime.UtcNow);
-    }
 }

--- a/Apsitvarkom.Models/Public/CleaningEventUpdateRequest.cs
+++ b/Apsitvarkom.Models/Public/CleaningEventUpdateRequest.cs
@@ -16,6 +16,6 @@ public class CleaningEventUpdateRequestValidator : AbstractValidator<CleaningEve
     public CleaningEventUpdateRequestValidator()
     {
         RuleFor(l => l.Id).NotNull();
-        RuleFor(l => l.StartTime).GreaterThan(DateTime.UtcNow);
+        RuleFor(l => l.StartTime).NotNull().GreaterThan(DateTime.UtcNow);
     }
 }

--- a/Apsitvarkom.Models/Public/CoordinatesCreateRequest.cs
+++ b/Apsitvarkom.Models/Public/CoordinatesCreateRequest.cs
@@ -1,18 +1,7 @@
-﻿using FluentValidation;
-
-namespace Apsitvarkom.Models.Public;
+﻿namespace Apsitvarkom.Models.Public;
 
 public class CoordinatesCreateRequest
 {
     public double? Latitude { get; set; }
     public double? Longitude { get; set; }
-}
-
-public class CoordinatesCreateRequestValidator : AbstractValidator<CoordinatesCreateRequest>
-{
-    public CoordinatesCreateRequestValidator()
-    {
-        RuleFor(coordinates => coordinates.Latitude).NotNull().InclusiveBetween(-90.0, 90.0);
-        RuleFor(coordinates => coordinates.Longitude).NotNull().InclusiveBetween(-180.0, 180.0);
-    }
 }

--- a/Apsitvarkom.Models/Public/CoordinatesResponse.cs
+++ b/Apsitvarkom.Models/Public/CoordinatesResponse.cs
@@ -1,18 +1,7 @@
-﻿using FluentValidation;
-
-namespace Apsitvarkom.Models.Public;
+﻿namespace Apsitvarkom.Models.Public;
 
 public class CoordinatesResponse
 {
     public double Latitude { get; set; }
     public double Longitude { get; set; }
-}
-
-public class CoordinatesResponseValidator : AbstractValidator<CoordinatesResponse>
-{
-    public CoordinatesResponseValidator()
-    {
-        RuleFor(coordinates => coordinates.Latitude).InclusiveBetween(-90.0, 90.0);
-        RuleFor(coordinates => coordinates.Longitude).InclusiveBetween(-180.0, 180.0);
-    }
 }

--- a/Apsitvarkom.Models/Public/LocationCreateRequest.cs
+++ b/Apsitvarkom.Models/Public/LocationCreateRequest.cs
@@ -1,17 +1,6 @@
-﻿using FluentValidation;
-
-namespace Apsitvarkom.Models.Public;
+﻿namespace Apsitvarkom.Models.Public;
 
 public class LocationCreateRequest
 {
     public CoordinatesCreateRequest? Coordinates { get; set; }
-}
-
-public class LocationCreateRequestValidator : AbstractValidator<LocationCreateRequest>
-{
-    public LocationCreateRequestValidator(IValidator<CoordinatesCreateRequest> coordinatesCreateRequestValidator)
-    {
-        RuleFor(l => l.Coordinates).NotNull();
-        RuleFor(l => l.Coordinates!).SetValidator(coordinatesCreateRequestValidator).When(l => l.Coordinates is not null);
-    }
 }

--- a/Apsitvarkom.Models/Public/LocationResponse.cs
+++ b/Apsitvarkom.Models/Public/LocationResponse.cs
@@ -1,18 +1,7 @@
-﻿using FluentValidation;
-
-namespace Apsitvarkom.Models.Public;
+﻿namespace Apsitvarkom.Models.Public;
 
 public class LocationResponse
 {
     public CoordinatesResponse Coordinates { get; set; } = new();
     public TranslatedResponse<string> Title { get; set; } = new();
-}
-
-public class LocationResponseValidator : AbstractValidator<LocationResponse>
-{
-    public LocationResponseValidator(IValidator<CoordinatesResponse> coordinatesResponseValidator, IValidator<TranslatedResponse<string>> translatedResponseStringValidator)
-    {
-        RuleFor(location => location.Coordinates).SetValidator(coordinatesResponseValidator);
-        RuleFor(location => location.Title).SetValidator(translatedResponseStringValidator);
-    }
 }

--- a/Apsitvarkom.Models/Public/ObjectIdentifyRequest.cs
+++ b/Apsitvarkom.Models/Public/ObjectIdentifyRequest.cs
@@ -1,16 +1,6 @@
-﻿using FluentValidation;
-
-namespace Apsitvarkom.Models.Public;
+﻿namespace Apsitvarkom.Models.Public;
 
 public class ObjectIdentifyRequest
 {
     public Guid? Id { get; set; }
-}
-
-public class ObjectIdentifyRequestValidator : AbstractValidator<ObjectIdentifyRequest>
-{
-    public ObjectIdentifyRequestValidator()
-    {
-        RuleFor(l => l.Id).NotNull();
-    }
 }

--- a/Apsitvarkom.Models/Public/PollutedLocationCreateRequest.cs
+++ b/Apsitvarkom.Models/Public/PollutedLocationCreateRequest.cs
@@ -1,5 +1,4 @@
-﻿using FluentValidation;
-using static Apsitvarkom.Models.PollutedLocation;
+﻿using static Apsitvarkom.Models.PollutedLocation;
 
 namespace Apsitvarkom.Models.Public;
 
@@ -12,16 +11,4 @@ public class PollutedLocationCreateRequest
     public SeverityLevel? Severity { get; set; }
 
     public string? Notes { get; set; }
-}
-
-public class PollutedLocationCreateRequestValidator : AbstractValidator<PollutedLocationCreateRequest>
-{
-    public PollutedLocationCreateRequestValidator(IValidator<LocationCreateRequest> locationCreateRequestValidator)
-    {
-        RuleFor(l => l.Radius).NotNull().GreaterThanOrEqualTo(1);
-        RuleFor(l => l.Severity).NotNull();
-
-        RuleFor(l => l.Location).NotNull();
-        RuleFor(l => l.Location!).SetValidator(locationCreateRequestValidator).When(l => l.Location is not null);
-    }
 }

--- a/Apsitvarkom.Models/Public/PollutedLocationResponse.cs
+++ b/Apsitvarkom.Models/Public/PollutedLocationResponse.cs
@@ -1,5 +1,4 @@
-﻿using FluentValidation;
-using static Apsitvarkom.Models.PollutedLocation;
+﻿using static Apsitvarkom.Models.PollutedLocation;
 
 namespace Apsitvarkom.Models.Public;
 
@@ -20,15 +19,4 @@ public class PollutedLocationResponse
     public string? Notes { get; set; }
 
     public List<CleaningEventResponse> Events { get; set; } = new();
-}
-
-public class PollutedLocationResponseValidator : AbstractValidator<PollutedLocationResponse>
-{
-    public PollutedLocationResponseValidator(IValidator<LocationResponse> locationResponseValidator)
-    {
-        RuleFor(l => l.Location).SetValidator(locationResponseValidator);
-
-        RuleFor(l => l.Radius).GreaterThanOrEqualTo(1);
-        RuleFor(l => l.Progress).InclusiveBetween(0, 100);
-    }
 }

--- a/Apsitvarkom.Models/Public/PollutedLocationUpdateRequest.cs
+++ b/Apsitvarkom.Models/Public/PollutedLocationUpdateRequest.cs
@@ -1,5 +1,4 @@
-﻿using FluentValidation;
-using static Apsitvarkom.Models.PollutedLocation;
+﻿using static Apsitvarkom.Models.PollutedLocation;
 
 namespace Apsitvarkom.Models.Public;
 
@@ -12,14 +11,4 @@ public class PollutedLocationUpdateRequest
     public SeverityLevel? Severity { get; set; }
 
     public string? Notes { get; set; }
-}
-
-public class PollutedLocationUpdateRequestValidator : AbstractValidator<PollutedLocationUpdateRequest>
-{
-    public PollutedLocationUpdateRequestValidator()
-    {
-       RuleFor(l => l.Id).NotNull();
-       RuleFor(l => l.Radius).NotNull().GreaterThanOrEqualTo(1);
-       RuleFor(l => l.Severity).NotNull();
-    }
 }

--- a/Apsitvarkom.Models/Public/PollutedLocationUpdateRequest.cs
+++ b/Apsitvarkom.Models/Public/PollutedLocationUpdateRequest.cs
@@ -19,6 +19,7 @@ public class PollutedLocationUpdateRequestValidator : AbstractValidator<Polluted
     public PollutedLocationUpdateRequestValidator()
     {
        RuleFor(l => l.Id).NotNull();
-       RuleFor(l => l.Radius).GreaterThanOrEqualTo(1);
+       RuleFor(l => l.Radius).NotNull().GreaterThanOrEqualTo(1);
+       RuleFor(l => l.Severity).NotNull();
     }
 }

--- a/Apsitvarkom.Models/Public/PollutedLocationUpdateRequest.cs
+++ b/Apsitvarkom.Models/Public/PollutedLocationUpdateRequest.cs
@@ -11,8 +11,6 @@ public class PollutedLocationUpdateRequest
 
     public SeverityLevel? Severity { get; set; }
 
-    public int? Progress { get; set; }
-
     public string? Notes { get; set; }
 }
 
@@ -22,6 +20,5 @@ public class PollutedLocationUpdateRequestValidator : AbstractValidator<Polluted
     {
        RuleFor(l => l.Id).NotNull();
        RuleFor(l => l.Radius).GreaterThanOrEqualTo(1);
-       RuleFor(l => l.Progress).InclusiveBetween(0, 100);
     }
 }

--- a/Apsitvarkom.Models/Public/TranslatedResponse.cs
+++ b/Apsitvarkom.Models/Public/TranslatedResponse.cs
@@ -1,18 +1,7 @@
-﻿using FluentValidation;
-
-namespace Apsitvarkom.Models.Public;
+﻿namespace Apsitvarkom.Models.Public;
 
 public class TranslatedResponse<T>
 {
     public T En { get; set; } = default!;
     public T Lt { get; set; } = default!;
-}
-
-public class TranslatedResponseStringValidator : AbstractValidator<TranslatedResponse<string>>
-{
-    public TranslatedResponseStringValidator()
-    {
-        RuleFor(l => l.En).NotNull();
-        RuleFor(l => l.Lt).NotNull();
-    }
 }

--- a/Apsitvarkom.UnitTests/Api/Controllers/CleaningEventControllerTests.cs
+++ b/Apsitvarkom.UnitTests/Api/Controllers/CleaningEventControllerTests.cs
@@ -63,7 +63,7 @@ public class CleaningEventControllerTests
             _pollutedLocationRepository.Object,
             _mapper, 
             new ObjectIdentifyRequestValidator(),
-            new CleaningEventCreateRequestValidator(),
+            new CleaningEventCreateRequestValidator(_repository.Object),
             new CleaningEventUpdateRequestValidator(_repository.Object),
             new CleaningEventFinalizeRequestValidator(_pollutedLocationRepository.Object)
         );
@@ -76,7 +76,7 @@ public class CleaningEventControllerTests
             _pollutedLocationRepository.Object,
             _mapper, 
             new ObjectIdentifyRequestValidator(),
-            new CleaningEventCreateRequestValidator(),
+            new CleaningEventCreateRequestValidator(_repository.Object),
             new CleaningEventUpdateRequestValidator(_repository.Object),
             new CleaningEventFinalizeRequestValidator(_pollutedLocationRepository.Object)
     ), Is.Not.Null);

--- a/Apsitvarkom.UnitTests/Api/Controllers/CleaningEventControllerTests.cs
+++ b/Apsitvarkom.UnitTests/Api/Controllers/CleaningEventControllerTests.cs
@@ -61,7 +61,7 @@ public class CleaningEventControllerTests
             _mapper, 
             new ObjectIdentifyRequestValidator(),
             new CleaningEventCreateRequestValidator(),
-            new CleaningEventUpdateRequestValidator()
+            new CleaningEventUpdateRequestValidator(_repository.Object),
         );
     }
 
@@ -73,7 +73,7 @@ public class CleaningEventControllerTests
             _mapper, 
             new ObjectIdentifyRequestValidator(),
             new CleaningEventCreateRequestValidator(),
-            new CleaningEventUpdateRequestValidator()
+            new CleaningEventUpdateRequestValidator(_repository.Object),
         ), Is.Not.Null);
     #endregion
 
@@ -404,7 +404,7 @@ public class CleaningEventControllerTests
 
         var actionResult = await _controller.Update(updateRequest);
 
-        _repository.Verify(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<CleaningEvent, bool>>>()), Times.Once);
+        _repository.Verify(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<CleaningEvent, bool>>>()), Times.Exactly(2));
         _repository.Verify(r => r.UpdateAsync(It.IsAny<CleaningEvent>()), Times.Never);
 
         Assert.That(actionResult.Result, Is.TypeOf<NotFoundObjectResult>());
@@ -430,7 +430,7 @@ public class CleaningEventControllerTests
 
         var actionResult = await _controller.Update(updateRequest);
 
-        _repository.Verify(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<CleaningEvent, bool>>>()), Times.Once);
+        _repository.Verify(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<CleaningEvent, bool>>>()), Times.Exactly(2));
         _repository.Verify(r => r.UpdateAsync(It.IsAny<CleaningEvent>()), Times.Once);
 
         Assert.That(actionResult.Result, Is.TypeOf<StatusCodeResult>());
@@ -456,7 +456,7 @@ public class CleaningEventControllerTests
 
         var actionResult = await _controller.Update(updateRequest);
 
-        _repository.Verify(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<CleaningEvent, bool>>>()), Times.Once);
+        _repository.Verify(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<CleaningEvent, bool>>>()), Times.Exactly(2));
         _repository.Verify(r => r.UpdateAsync(It.IsAny<CleaningEvent>()), Times.Once);
 
         Assert.That(actionResult.Result, Is.TypeOf<OkObjectResult>());

--- a/Apsitvarkom.UnitTests/Api/Controllers/CleaningEventControllerTests.cs
+++ b/Apsitvarkom.UnitTests/Api/Controllers/CleaningEventControllerTests.cs
@@ -1,8 +1,9 @@
 ﻿using System.Linq.Expressions;
 using Apsitvarkom.Api.Controllers;
 using Apsitvarkom.DataAccess;
+using Apsitvarkom.ModelActions.Mapping;
+using Apsitvarkom.ModelActions.Validation;
 using Apsitvarkom.Models;
-using Apsitvarkom.Models.Mapping;
 using Apsitvarkom.Models.Public;
 using AutoMapper;
 using Microsoft.AspNetCore.Http;

--- a/Apsitvarkom.UnitTests/Api/Controllers/CleaningEventControllerTests.cs
+++ b/Apsitvarkom.UnitTests/Api/Controllers/CleaningEventControllerTests.cs
@@ -25,21 +25,24 @@ public class CleaningEventControllerTests
         {
             Id = Guid.Parse("3408f21c-90d3-470f-afe2-0b6f51c8e405"),
             PollutedLocationId = Guid.Parse("6f61b9b1-8aea-4b95-ba49-32af5e96fb9c"),
-            StartTime = DateTime.Parse("2026-12-11T10:11:12Z")
+            StartTime = DateTime.Parse("2026-12-11T10:11:12Z"),
+            IsFinalized = false
         },
         new()
         {
             Id = Guid.Parse("2482d7a9-e64c-4159-a570-f51d500f0806"),
             PollutedLocationId = Guid.Parse("548d8c82-2822-482c-a801-76916d4b770d"),
             StartTime = DateTime.Parse("2032-01-01T00:11:22Z"),
-            Notes = "So many fireworks leftovers..."
+            Notes = "So many fireworks leftovers...",
+            IsFinalized = true
         },
         new()
         {
             Id = Guid.Parse("6e18987e-497b-4a35-820f-283321c9a9dd"),
             PollutedLocationId = Guid.Parse("6f61b9b1-8aea-4b95-ba49-32af5e96fb9c"),
             StartTime = DateTime.Parse("2052-12-23T10:11:12Z"),
-            Notes = "The christmas tree caught on fire."
+            Notes = "The christmas tree caught on fire.",
+            IsFinalized = false
         }
     };
 
@@ -62,6 +65,7 @@ public class CleaningEventControllerTests
             new ObjectIdentifyRequestValidator(),
             new CleaningEventCreateRequestValidator(),
             new CleaningEventUpdateRequestValidator(_repository.Object),
+            new CleaningEventFinalizeRequestValidator(_pollutedLocationRepository.Object)
         );
     }
 
@@ -74,7 +78,8 @@ public class CleaningEventControllerTests
             new ObjectIdentifyRequestValidator(),
             new CleaningEventCreateRequestValidator(),
             new CleaningEventUpdateRequestValidator(_repository.Object),
-        ), Is.Not.Null);
+            new CleaningEventFinalizeRequestValidator(_pollutedLocationRepository.Object)
+    ), Is.Not.Null);
     #endregion
 
     #region GetAll tests
@@ -108,6 +113,7 @@ public class CleaningEventControllerTests
                 Assert.That(resultEvent.StartTime, Is.EqualTo(cleaningEvent.StartTime));
                 Assert.That(resultEvent.Notes, Is.EqualTo(cleaningEvent.Notes));
                 Assert.That(resultEvent.PollutedLocationId, Is.EqualTo(cleaningEvent.PollutedLocationId));
+                Assert.That(resultEvent.Status, Is.TypeOf<CleaningEventResponse.State>());
             });
         }
     }
@@ -158,6 +164,7 @@ public class CleaningEventControllerTests
             Assert.That(resultEvent.StartTime, Is.EqualTo(cleaningEvent.StartTime));
             Assert.That(resultEvent.Notes, Is.EqualTo(cleaningEvent.Notes));
             Assert.That(resultEvent.PollutedLocationId, Is.EqualTo(cleaningEvent.PollutedLocationId));
+            Assert.That(resultEvent.Status, Is.TypeOf<CleaningEventResponse.State>());
         });
     }
 
@@ -250,13 +257,14 @@ public class CleaningEventControllerTests
         Assert.That(result.StatusCode, Is.EqualTo(StatusCodes.Status201Created));
 
         Assert.That(result.Value, Is.Not.Null.And.TypeOf<CleaningEventResponse>());
-        var resultLocation = result.Value as CleaningEventResponse;
-        Assert.That(resultLocation, Is.Not.Null);
+        var resultEvent = result.Value as CleaningEventResponse;
+        Assert.That(resultEvent, Is.Not.Null);
         Assert.Multiple(() =>
         {
-            Assert.That(resultLocation.PollutedLocationId, expression: Is.EqualTo(createRequest.PollutedLocationId));
-            Assert.That(resultLocation.StartTime, Is.EqualTo(createRequest.StartTime));
-            Assert.That(resultLocation.Notes, Is.EqualTo(createRequest.Notes));
+            Assert.That(resultEvent.PollutedLocationId, expression: Is.EqualTo(createRequest.PollutedLocationId));
+            Assert.That(resultEvent.StartTime, Is.EqualTo(createRequest.StartTime));
+            Assert.That(resultEvent.Notes, Is.EqualTo(createRequest.Notes));
+            Assert.That(resultEvent.Status, Is.TypeOf<CleaningEventResponse.State>());
         });
     }
 
@@ -432,7 +440,7 @@ public class CleaningEventControllerTests
 
         _repository.Verify(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<CleaningEvent, bool>>>()), Times.Exactly(2));
         _repository.Verify(r => r.UpdateAsync(It.IsAny<CleaningEvent>()), Times.Once);
-
+        
         Assert.That(actionResult.Result, Is.TypeOf<StatusCodeResult>());
         var result = actionResult.Result as StatusCodeResult;
 
@@ -458,7 +466,7 @@ public class CleaningEventControllerTests
 
         _repository.Verify(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<CleaningEvent, bool>>>()), Times.Exactly(2));
         _repository.Verify(r => r.UpdateAsync(It.IsAny<CleaningEvent>()), Times.Once);
-
+        
         Assert.That(actionResult.Result, Is.TypeOf<OkObjectResult>());
         var result = actionResult.Result as OkObjectResult;
 
@@ -473,7 +481,151 @@ public class CleaningEventControllerTests
             Assert.That(resultEvent.Id, Is.EqualTo(cleaningEvent.Id));
             Assert.That(resultEvent.StartTime, Is.EqualTo(cleaningEvent.StartTime));
             Assert.That(resultEvent.Notes, Is.EqualTo(cleaningEvent.Notes));
+            Assert.That(resultEvent.Status, Is.TypeOf<CleaningEventResponse.State>());
         });
+    }
+    #endregion
+
+    #region Finalize tests
+    [Test]
+    public async Task Finalize_InvalidRequestEntered_ValidationResultsInBadRequestResponseReturned()
+    {
+        var finalizeRequest = new CleaningEventFinalizeRequest
+        {
+            Id = null
+        };
+
+        var actionResult = await _controller.Finalize(finalizeRequest);
+
+        _repository.Verify(r => r.UpdateAsync(It.IsAny<CleaningEvent>()), Times.Never);
+
+        Assert.That(actionResult, Is.TypeOf<BadRequestObjectResult>());
+        var result = actionResult as BadRequestObjectResult;
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
+        Assert.That(result.Value, Is.Not.Null.And.Not.Empty);
+    }
+
+    [Test]
+    public async Task Finalize_RepositoryReturnsNull_NotFoundActionResultReturned()
+    {
+        var finalizeRequest = new CleaningEventFinalizeRequest
+        {
+            Id = Guid.NewGuid(),
+            NewProgress = 50
+        };
+
+        _pollutedLocationRepository.Setup(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>())).ReturnsAsync((PollutedLocation?)null);
+
+        var actionResult = await _controller.Finalize(finalizeRequest);
+
+        _pollutedLocationRepository.Verify(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>()), Times.Exactly(2));
+
+        Assert.That(actionResult, Is.TypeOf<NotFoundObjectResult>());
+        var result = actionResult as NotFoundObjectResult;
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+        Assert.That(result.Value, Is.Not.Null.And.Not.Empty);
+    }
+
+    [Test]
+    public async Task Finalize_RepositoryThrowsAcquiringPollutedLocation_Status500InternalServerErrorReturned()
+    {
+        var finalizeRequest = new CleaningEventFinalizeRequest
+        {
+            Id = Guid.NewGuid(),
+            NewProgress = 50
+        };
+
+        _pollutedLocationRepository.Setup(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>())).Throws<Exception>();
+
+        var actionResult = await _controller.Finalize(finalizeRequest);
+
+        Assert.That(actionResult, Is.TypeOf<StatusCodeResult>());
+        var result = actionResult as StatusCodeResult;
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.StatusCode, Is.EqualTo(StatusCodes.Status500InternalServerError));
+
+        _pollutedLocationRepository.Verify(r => r.UpdateAsync(It.IsAny<PollutedLocation>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Finalize_RepositoryThrowsUpdatingPollutedLocation_Status500InternalServerErrorReturned()
+    {
+        var finalizeRequest = new CleaningEventFinalizeRequest
+        {
+            Id = Guid.NewGuid(),
+            NewProgress = 50
+        };
+
+        var relatedPollutedLocation = new PollutedLocation
+        {
+            Id = Guid.NewGuid(),
+            Progress = 12,
+            Events = new List<CleaningEvent>
+            {
+                new()
+                {
+                    Id = (Guid)finalizeRequest.Id,
+                    IsFinalized = false,
+                    StartTime = DateTime.UtcNow.AddDays(-1).ToUniversalTime()
+                }
+            }
+        };
+
+        _pollutedLocationRepository.Setup(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>())).ReturnsAsync(relatedPollutedLocation);
+        _pollutedLocationRepository.Setup(r => r.UpdateAsync(It.Is<PollutedLocation>(x => x.Id == relatedPollutedLocation.Id))).Throws<Exception>();
+
+        var actionResult = await _controller.Finalize(finalizeRequest);
+
+        Assert.That(actionResult, Is.TypeOf<StatusCodeResult>());
+        var result = actionResult as StatusCodeResult;
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.StatusCode, Is.EqualTo(StatusCodes.Status500InternalServerError));
+
+        _pollutedLocationRepository.Verify(r => r.UpdateAsync(It.IsAny<PollutedLocation>()), Times.Once);
+    }
+
+    [Test]
+    public async Task Finalize_RepositoryGetsAndDeletesOnce_NoContentResultReturned()
+    {
+        var finalizeRequest = new CleaningEventFinalizeRequest
+        {
+            Id = Guid.NewGuid(),
+            NewProgress = 50
+        };
+
+        var relatedPollutedLocation = new PollutedLocation
+        {
+            Id = Guid.NewGuid(),
+            Progress = 12,
+            Events = new List<CleaningEvent>
+            {
+                new()
+                {
+                    Id = (Guid)finalizeRequest.Id,
+                    IsFinalized = false,
+                    StartTime = DateTime.UtcNow.AddDays(-1).ToUniversalTime()
+                }
+            }
+        };
+
+        _pollutedLocationRepository.Setup(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>())).ReturnsAsync(relatedPollutedLocation);
+
+        var actionResult = await _controller.Finalize(finalizeRequest);
+
+        _pollutedLocationRepository.Verify(r => r.UpdateAsync(It.IsAny<PollutedLocation>()), Times.Once);
+        _pollutedLocationRepository.Verify(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>()), Times.Exactly(2));
+
+        Assert.That(actionResult, Is.TypeOf<NoContentResult>());
+        var result = actionResult as NoContentResult;
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.StatusCode, Is.EqualTo(StatusCodes.Status204NoContent));
     }
     #endregion
 

--- a/Apsitvarkom.UnitTests/Api/Controllers/CleaningEventControllerTests.cs
+++ b/Apsitvarkom.UnitTests/Api/Controllers/CleaningEventControllerTests.cs
@@ -63,7 +63,7 @@ public class CleaningEventControllerTests
             _pollutedLocationRepository.Object,
             _mapper, 
             new ObjectIdentifyRequestValidator(),
-            new CleaningEventCreateRequestValidator(_repository.Object),
+            new CleaningEventCreateRequestValidator(_pollutedLocationRepository.Object),
             new CleaningEventUpdateRequestValidator(_repository.Object),
             new CleaningEventFinalizeRequestValidator(_pollutedLocationRepository.Object)
         );
@@ -76,7 +76,7 @@ public class CleaningEventControllerTests
             _pollutedLocationRepository.Object,
             _mapper, 
             new ObjectIdentifyRequestValidator(),
-            new CleaningEventCreateRequestValidator(_repository.Object),
+            new CleaningEventCreateRequestValidator(_pollutedLocationRepository.Object),
             new CleaningEventUpdateRequestValidator(_repository.Object),
             new CleaningEventFinalizeRequestValidator(_pollutedLocationRepository.Object)
     ), Is.Not.Null);

--- a/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
+++ b/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
@@ -96,7 +96,7 @@ public class PollutedLocationControllerTests
             new CoordinatesCreateRequestValidator(),
             new PollutedLocationCreateRequestValidator(new LocationCreateRequestValidator(new CoordinatesCreateRequestValidator())),
             new ObjectIdentifyRequestValidator(),
-            new PollutedLocationUpdateRequestValidator()
+            new PollutedLocationUpdateRequestValidator(_repository.Object)
         );
     }
 
@@ -109,7 +109,7 @@ public class PollutedLocationControllerTests
             new CoordinatesCreateRequestValidator(),
             new PollutedLocationCreateRequestValidator(new LocationCreateRequestValidator(new CoordinatesCreateRequestValidator())),
             new ObjectIdentifyRequestValidator(),
-            new PollutedLocationUpdateRequestValidator()
+            new PollutedLocationUpdateRequestValidator(_repository.Object)
         ), Is.Not.Null);
     #endregion
 
@@ -551,7 +551,7 @@ public class PollutedLocationControllerTests
 
         var actionResult = await _controller.Update(updateRequest);
 
-        _repository.Verify(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>()), Times.Once);
+        _repository.Verify(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>()), Times.Exactly(2));
         _repository.Verify(r => r.UpdateAsync(It.IsAny<PollutedLocation>()), Times.Never);
 
         Assert.That(actionResult.Result, Is.TypeOf<NotFoundObjectResult>());
@@ -577,7 +577,7 @@ public class PollutedLocationControllerTests
 
         var actionResult = await _controller.Update(updateRequest);
 
-        _repository.Verify(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>()), Times.Once);
+        _repository.Verify(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>()), Times.Exactly(2));
         _repository.Verify(r => r.UpdateAsync(It.IsAny<PollutedLocation>()), Times.Once);
 
         Assert.That(actionResult.Result, Is.TypeOf<StatusCodeResult>());
@@ -602,7 +602,7 @@ public class PollutedLocationControllerTests
 
         var actionResult = await _controller.Update(updateRequest);
 
-        _repository.Verify(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>()), Times.Once);
+        _repository.Verify(r => r.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>()), Times.Exactly(2));
         _repository.Verify(r => r.UpdateAsync(It.IsAny<PollutedLocation>()), Times.Once);
 
         Assert.That(actionResult.Result, Is.TypeOf<OkObjectResult>());

--- a/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
+++ b/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
@@ -1,8 +1,9 @@
 ﻿using System.Linq.Expressions;
 using Apsitvarkom.Api.Controllers;
 using Apsitvarkom.DataAccess;
+using Apsitvarkom.ModelActions.Mapping;
+using Apsitvarkom.ModelActions.Validation;
 using Apsitvarkom.Models;
-using Apsitvarkom.Models.Mapping;
 using Apsitvarkom.Models.Public;
 using AutoMapper;
 using Microsoft.AspNetCore.Http;
@@ -149,7 +150,7 @@ public class PollutedLocationControllerTests
                 Assert.That(resultLocation.Location.Coordinates.Latitude, Is.EqualTo(location.Location.Coordinates.Latitude));
                 Assert.That(resultLocation.Location.Coordinates.Longitude, Is.EqualTo(location.Location.Coordinates.Longitude));
                 Assert.That(resultLocation.Notes, Is.EqualTo(location.Notes));
-                Assert.That(resultLocation.Events.Count, Is.EqualTo(location.Events.Count));
+                Assert.That(resultLocation.Events, Has.Count.EqualTo(location.Events.Count));
                 for (var j = 0; j < resultLocation.Events.Count; ++j)
                 {
                     Assert.That(resultLocation.Events[j].PollutedLocationId, Is.EqualTo(location.Events[j].PollutedLocationId));
@@ -219,7 +220,7 @@ public class PollutedLocationControllerTests
                 Assert.That(resultLocation.Location.Title.Lt, Is.EqualTo(location.Location.Title.Lithuanian));
                 Assert.That(resultLocation.Location.Coordinates.Latitude, Is.EqualTo(location.Location.Coordinates.Latitude));
                 Assert.That(resultLocation.Location.Coordinates.Longitude, Is.EqualTo(location.Location.Coordinates.Longitude));
-                Assert.That(resultLocation.Events.Count, Is.EqualTo(location.Events.Count));
+                Assert.That(resultLocation.Events, Has.Count.EqualTo(location.Events.Count));
                 for (var j = 0; j < resultLocation.Events.Count; ++j)
                 {
                     Assert.That(resultLocation.Events[j].PollutedLocationId, Is.EqualTo(location.Events[j].PollutedLocationId));
@@ -254,7 +255,7 @@ public class PollutedLocationControllerTests
 
         var errorList = result.Value as List<string>;
         Assert.That(errorList, Is.Not.Null);
-        Assert.That(errorList.Count, Is.EqualTo(2));
+        Assert.That(errorList, Has.Count.EqualTo(2));
     }
 
     [Test]
@@ -313,7 +314,7 @@ public class PollutedLocationControllerTests
             Assert.That(resultLocation.Location.Title.Lt, Is.EqualTo(location.Location.Title.Lithuanian));
             Assert.That(resultLocation.Location.Coordinates.Latitude, Is.EqualTo(location.Location.Coordinates.Latitude));
             Assert.That(resultLocation.Location.Coordinates.Longitude, Is.EqualTo(location.Location.Coordinates.Longitude));
-            Assert.That(resultLocation.Events.Count, Is.EqualTo(location.Events.Count));
+            Assert.That(resultLocation.Events, Has.Count.EqualTo(location.Events.Count));
             for (var j = 0; j < resultLocation.Events.Count; ++j)
             {
                 Assert.That(resultLocation.Events[j].PollutedLocationId, Is.EqualTo(location.Events[j].PollutedLocationId));
@@ -624,7 +625,7 @@ public class PollutedLocationControllerTests
             Assert.That(resultLocation.Location.Title.Lt, Is.EqualTo(location.Location.Title.Lithuanian));
             Assert.That(resultLocation.Location.Coordinates.Latitude, Is.EqualTo(location.Location.Coordinates.Latitude));
             Assert.That(resultLocation.Location.Coordinates.Longitude, Is.EqualTo(location.Location.Coordinates.Longitude));
-            Assert.That(resultLocation.Events.Count, Is.EqualTo(location.Events.Count));
+            Assert.That(resultLocation.Events, Has.Count.EqualTo(location.Events.Count));
             for (var j = 0; j < resultLocation.Events.Count; ++j)
             {
                 Assert.That(resultLocation.Events[j].PollutedLocationId, Is.EqualTo(location.Events[j].PollutedLocationId));

--- a/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
+++ b/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
@@ -519,7 +519,6 @@ public class PollutedLocationControllerTests
         var updateRequest = new PollutedLocationUpdateRequest
         {
             Id = Guid.NewGuid(),
-            Progress = 12,
             Radius = 3,
             Severity = PollutedLocation.SeverityLevel.High
         };
@@ -543,7 +542,6 @@ public class PollutedLocationControllerTests
         var updateRequest = new PollutedLocationUpdateRequest
         {
             Id = Guid.NewGuid(),
-            Progress = 12,
             Radius = 3,
             Severity = PollutedLocation.SeverityLevel.High
         };
@@ -569,7 +567,6 @@ public class PollutedLocationControllerTests
         var updateRequest = new PollutedLocationUpdateRequest
         {
             Id = Guid.NewGuid(),
-            Progress = 12,
             Radius = 3,
             Severity = PollutedLocation.SeverityLevel.High
         };

--- a/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
+++ b/Apsitvarkom.UnitTests/Api/Controllers/PollutedLocationControllerTests.cs
@@ -45,13 +45,15 @@ public class PollutedLocationControllerTests
                     Id = Guid.NewGuid(),
                     PollutedLocationId = Guid.Parse("7df570d5-efbb-4bf5-a21c-b9d33dafca36"),
                     StartTime = DateTime.Parse("2023-01-01T00:11:22Z"),
-                    Notes = "So many fireworks leftovers..."
+                    Notes = "So many fireworks leftovers...",
+                    IsFinalized = true
                 },
                 new()
                 {
                     Id = Guid.NewGuid(),
                     PollutedLocationId = Guid.Parse("7df570d5-efbb-4bf5-a21c-b9d33dafca36"),
                     StartTime = DateTime.Parse("2022-12-23T10:11:12Z"),
+                    IsFinalized = false
                 },
             }
         },

--- a/Apsitvarkom.UnitTests/Apsitvarkom.UnitTests.csproj
+++ b/Apsitvarkom.UnitTests/Apsitvarkom.UnitTests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Apsitvarkom.Api\Apsitvarkom.Api.csproj" />
     <ProjectReference Include="..\Apsitvarkom.DataAccess\Apsitvarkom.DataAccess.csproj" />
+    <ProjectReference Include="..\Apsitvarkom.ModelActions\Apsitvarkom.ModelActions.csproj" />
     <ProjectReference Include="..\Apsitvarkom.Models\Apsitvarkom.Models.csproj" />
   </ItemGroup>
 

--- a/Apsitvarkom.UnitTests/ModelActions/Mapping/CleaningEventMappingTests.cs
+++ b/Apsitvarkom.UnitTests/ModelActions/Mapping/CleaningEventMappingTests.cs
@@ -114,14 +114,18 @@ public class CleaningEventMappingTests
 
     #region Response mappings
     [Test]
-    public void CleaningEventToCleaningEventResponse()
+    [TestCase(true, 0, CleaningEventResponse.State.Finalized)]
+    [TestCase(false, 1, CleaningEventResponse.State.Foreseen)]
+    [TestCase(false, -1, CleaningEventResponse.State.Finished)]
+    public void CleaningEventToCleaningEventResponse(bool isFinalized, int daysFromCurrentDate, CleaningEventResponse.State result)
     {
         var businessLogicObject = new CleaningEvent
         {
             Id = Guid.NewGuid(),
-            StartTime = new DateTime(2022, 9, 16, 21, 43, 31).ToUniversalTime(),
+            StartTime = DateTime.UtcNow.AddDays(daysFromCurrentDate).ToUniversalTime(),
             Notes = "Hello world",
-            PollutedLocationId = Guid.NewGuid()
+            PollutedLocationId = Guid.NewGuid(),
+            IsFinalized = isFinalized
         };
 
         var response = _mapper.Map<CleaningEventResponse>(businessLogicObject);
@@ -131,6 +135,7 @@ public class CleaningEventMappingTests
             Assert.That(response.StartTime, Is.EqualTo(businessLogicObject.StartTime));
             Assert.That(response.Notes, Is.EqualTo(businessLogicObject.Notes));
             Assert.That(response.PollutedLocationId, Is.EqualTo(businessLogicObject.PollutedLocationId));
+            Assert.That(response.Status, Is.EqualTo(result));
         });
     }
     #endregion

--- a/Apsitvarkom.UnitTests/ModelActions/Mapping/CleaningEventMappingTests.cs
+++ b/Apsitvarkom.UnitTests/ModelActions/Mapping/CleaningEventMappingTests.cs
@@ -1,9 +1,9 @@
-﻿using Apsitvarkom.Models;
-using Apsitvarkom.Models.Mapping;
+﻿using Apsitvarkom.ModelActions.Mapping;
+using Apsitvarkom.Models;
 using Apsitvarkom.Models.Public;
 using AutoMapper;
 
-namespace Apsitvarkom.UnitTests.Models.Mapping;
+namespace Apsitvarkom.UnitTests.ModelActions.Mapping;
 
 public class CleaningEventMappingTests
 {

--- a/Apsitvarkom.UnitTests/ModelActions/Mapping/PollutedLocationMappingTests.cs
+++ b/Apsitvarkom.UnitTests/ModelActions/Mapping/PollutedLocationMappingTests.cs
@@ -1,9 +1,9 @@
-﻿using Apsitvarkom.Models;
-using Apsitvarkom.Models.Mapping;
+﻿using Apsitvarkom.ModelActions.Mapping;
+using Apsitvarkom.Models;
 using Apsitvarkom.Models.Public;
 using AutoMapper;
 
-namespace Apsitvarkom.UnitTests.Models.Mapping;
+namespace Apsitvarkom.UnitTests.ModelActions.Mapping;
 
 public class PollutedLocationMappingTests
 {
@@ -234,7 +234,7 @@ public class PollutedLocationMappingTests
             Assert.That(pollutedLocation.Spotted, Is.EqualTo(businessLogicObject.Spotted));
             Assert.That(pollutedLocation.Progress, Is.EqualTo(businessLogicObject.Progress));
             Assert.That(pollutedLocation.Notes, Is.EqualTo(businessLogicObject.Notes));
-            Assert.That(pollutedLocation.Events.Count, Is.EqualTo(businessLogicObject.Events.Count));
+            Assert.That(pollutedLocation.Events, Has.Count.EqualTo(businessLogicObject.Events.Count));
             for (var j = 0; j < pollutedLocation.Events.Count; ++j)
             {
                 Assert.That(pollutedLocation.Events[j].PollutedLocationId, Is.EqualTo(businessLogicObject.Events[j].PollutedLocationId));

--- a/Apsitvarkom.UnitTests/ModelActions/Mapping/PollutedLocationMappingTests.cs
+++ b/Apsitvarkom.UnitTests/ModelActions/Mapping/PollutedLocationMappingTests.cs
@@ -209,12 +209,14 @@ public class PollutedLocationMappingTests
                     PollutedLocationId = pollutedLocationId,
                     Id = Guid.NewGuid(),
                     Notes = "Hello NPC",
+                    IsFinalized = true,
                     StartTime = new DateTime(2022, 10, 11, 12, 13, 14).ToUniversalTime(),
                 },
                 new()
                 {
                     PollutedLocationId = pollutedLocationId,
                     Id = Guid.NewGuid(),
+                    IsFinalized = true,
                     StartTime = new DateTime(2022, 11, 12, 13, 14, 15).ToUniversalTime(),
                 }
             }
@@ -241,6 +243,7 @@ public class PollutedLocationMappingTests
                 Assert.That(pollutedLocation.Events[j].Id, Is.EqualTo(businessLogicObject.Events[j].Id));
                 Assert.That(pollutedLocation.Events[j].Notes, Is.EqualTo(businessLogicObject.Events[j].Notes));
                 Assert.That(pollutedLocation.Events[j].StartTime, Is.EqualTo(businessLogicObject.Events[j].StartTime));
+                Assert.That(pollutedLocation.Events[j].Status, Is.EqualTo(CleaningEventResponse.State.Finalized));
             }
         });
     }

--- a/Apsitvarkom.UnitTests/ModelActions/Validation/CleaningEventCreateRequestValidationTests.cs
+++ b/Apsitvarkom.UnitTests/ModelActions/Validation/CleaningEventCreateRequestValidationTests.cs
@@ -1,7 +1,8 @@
-﻿using Apsitvarkom.Models.Public;
+﻿using Apsitvarkom.ModelActions.Validation;
+using Apsitvarkom.Models.Public;
 using FluentValidation;
 
-namespace Apsitvarkom.UnitTests.Models.Validation;
+namespace Apsitvarkom.UnitTests.ModelActions.Validation;
 
 public class CleaningEventCreateRequestValidationTests
 {
@@ -64,7 +65,7 @@ public class CleaningEventCreateRequestValidationTests
 
         Assert.That(result, Is.Not.Null);
         // Only 1 thing must error in the invalid input
-        Assert.That(result.Errors.Count, Is.EqualTo(1));
+        Assert.That(result.Errors, Has.Count.EqualTo(1));
         Assert.That(result.IsValid, Is.False);
     }
 }

--- a/Apsitvarkom.UnitTests/ModelActions/Validation/CleaningEventCreateRequestValidationTests.cs
+++ b/Apsitvarkom.UnitTests/ModelActions/Validation/CleaningEventCreateRequestValidationTests.cs
@@ -136,7 +136,7 @@ public class CleaningEventCreateRequestValidationTests
     }
 
     [Test]
-    public async Task ValidInputWithRepositoryCall_UpdateUnavailable_PollutedLocationTidiedUp_ShouldFailValidation()
+    public async Task ValidInputWithRepositoryCall_UpdateUnavailable_PollutedLocationCleanedUp_ShouldFailValidation()
     {
         var input = ValidCleaningEventCreateRequests.First();
         var pollutedLocation = new PollutedLocation

--- a/Apsitvarkom.UnitTests/ModelActions/Validation/CleaningEventCreateRequestValidationTests.cs
+++ b/Apsitvarkom.UnitTests/ModelActions/Validation/CleaningEventCreateRequestValidationTests.cs
@@ -1,12 +1,24 @@
-﻿using Apsitvarkom.ModelActions.Validation;
+﻿using Apsitvarkom.DataAccess;
+using Apsitvarkom.ModelActions.Validation;
+using Apsitvarkom.Models;
 using Apsitvarkom.Models.Public;
 using FluentValidation;
+using Moq;
+using System.Linq.Expressions;
 
 namespace Apsitvarkom.UnitTests.ModelActions.Validation;
 
 public class CleaningEventCreateRequestValidationTests
 {
-    private static readonly IValidator<CleaningEventCreateRequest> Validator = new CleaningEventCreateRequestValidator();
+    private IValidator<CleaningEventCreateRequest> _validator;
+    private Mock<IRepository<CleaningEvent>> _repository;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repository = new Mock<IRepository<CleaningEvent>>();
+        _validator = new CleaningEventCreateRequestValidator(_repository.Object);
+    }
 
     private static readonly CleaningEventCreateRequest[] ValidCleaningEventCreateRequests =
    {
@@ -50,7 +62,7 @@ public class CleaningEventCreateRequestValidationTests
     [TestCaseSource(nameof(ValidCleaningEventCreateRequests))]
     public async Task ValidInputShouldSucceedValidation(CleaningEventCreateRequest input)
     {
-        var result = await Validator.ValidateAsync(input);
+        var result = await _validator.ValidateAsync(input);
 
         Assert.That(result, Is.Not.Null);
         Assert.That(result.Errors, Is.Empty);
@@ -61,11 +73,59 @@ public class CleaningEventCreateRequestValidationTests
     [TestCaseSource(nameof(InvalidCleaningEventCreateRequests))]
     public async Task InvalidInputShouldFailValidation(CleaningEventCreateRequest input)
     {
-        var result = await Validator.ValidateAsync(input);
+        var result = await _validator.ValidateAsync(input);
 
         Assert.That(result, Is.Not.Null);
         // Only 1 thing must error in the invalid input
         Assert.That(result.Errors, Has.Count.EqualTo(1));
         Assert.That(result.IsValid, Is.False);
+    }
+
+    [Test]
+    public async Task ValidInputWithRepositoryCall_UpdateAvailable_ShouldSucceedValidation()
+    {
+        var input = ValidCleaningEventCreateRequests.First();
+
+        _repository.Setup(x => x.ExistsByPropertyAsync(It.IsAny<Expression<Func<CleaningEvent, bool>>>())).ReturnsAsync(false);
+
+        var result = await _validator.ValidateAsync(input);
+
+        _repository.Verify(x => x.ExistsByPropertyAsync(It.IsAny<Expression<Func<CleaningEvent, bool>>>()), Times.Once);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Errors, Is.Empty);
+        Assert.That(result.IsValid, Is.True);
+    }
+
+    [Test]
+    public async Task ValidInputWithRepositoryCall_UpdateUnavailable_ShouldFailValidation()
+    {
+        var input = ValidCleaningEventCreateRequests.First();
+
+        _repository.Setup(x => x.ExistsByPropertyAsync(It.IsAny<Expression<Func<CleaningEvent, bool>>>())).ReturnsAsync(true);
+
+        var result = await _validator.ValidateAsync(input);
+
+        _repository.Verify(x => x.ExistsByPropertyAsync(It.IsAny<Expression<Func<CleaningEvent, bool>>>()), Times.Once);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Errors, Has.Count.EqualTo(1));
+        Assert.That(result.IsValid, Is.False);
+    }
+
+    [Test]
+    public async Task ValidInputWithRepositoryCall_RepositoryThrows_NoErrorsReturned()
+    {
+        var input = ValidCleaningEventCreateRequests.First();
+
+        _repository.Setup(x => x.ExistsByPropertyAsync(It.IsAny<Expression<Func<CleaningEvent, bool>>>())).Throws<Exception>();
+
+        var result = await _validator.ValidateAsync(input);
+
+        _repository.Verify(x => x.ExistsByPropertyAsync(It.IsAny<Expression<Func<CleaningEvent, bool>>>()), Times.Once);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Errors, Is.Empty);
+        Assert.That(result.IsValid, Is.True);
     }
 }

--- a/Apsitvarkom.UnitTests/ModelActions/Validation/CleaningEventFinalizeRequestValidationTests.cs
+++ b/Apsitvarkom.UnitTests/ModelActions/Validation/CleaningEventFinalizeRequestValidationTests.cs
@@ -1,0 +1,209 @@
+﻿using System.Linq.Expressions;
+using Apsitvarkom.DataAccess;
+using Apsitvarkom.ModelActions.Validation;
+using Apsitvarkom.Models;
+using Apsitvarkom.Models.Public;
+using FluentValidation;
+using Moq;
+
+namespace Apsitvarkom.UnitTests.ModelActions.Validation;
+
+public class CleaningEventFinalizeRequestValidationTests
+{
+    private IValidator<CleaningEventFinalizeRequest> _validator;
+    private Mock<IPollutedLocationRepository> _repository;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repository = new Mock<IPollutedLocationRepository>();
+        _validator = new CleaningEventFinalizeRequestValidator(_repository.Object);
+    }
+
+    private static readonly CleaningEventFinalizeRequest[] ValidCleaningEventFinalizeRequests =
+    {
+        new()
+        {
+            Id = Guid.NewGuid(),
+            NewProgress = 12
+        }
+    };
+
+    private static readonly CleaningEventFinalizeRequest[] InvalidCleaningEventFinalizeRequests =
+   {
+        new()
+        {
+            // Missing id
+            NewProgress = 12,
+        },
+        new()
+        { 
+            // Missing NewProgress
+            Id = Guid.NewGuid(),
+        },
+        new()
+        { 
+            // Invalid NewProgress
+            Id = Guid.NewGuid(),
+            NewProgress = 101
+        },
+    };
+
+    [Test]
+    [TestCaseSource(nameof(ValidCleaningEventFinalizeRequests))]
+    public async Task ValidInputShouldSucceedValidation(CleaningEventFinalizeRequest input)
+    {
+        var result = await _validator.ValidateAsync(input);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Errors, Is.Empty);
+        Assert.That(result.IsValid, Is.True);
+    }
+
+    [Test]
+    [TestCaseSource(nameof(InvalidCleaningEventFinalizeRequests))]
+    public async Task InvalidInputShouldFailValidation(CleaningEventFinalizeRequest input)
+    {
+        var result = await _validator.ValidateAsync(input);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Errors, Has.Count.EqualTo(1));
+        Assert.That(result.IsValid, Is.False);
+    }
+
+    [Test]
+    public async Task ValidInputWithRepositoryCall_FinalizeAvailable_ShouldSucceedValidation()
+    {
+        var input = new CleaningEventFinalizeRequest
+        {
+            Id = Guid.NewGuid(),
+            NewProgress = 20
+        };
+
+        var pollutedLocation = new PollutedLocation
+        {
+            Progress = 15,
+            Events = new List<CleaningEvent>
+            {
+                new() { Id = (Guid)input.Id, IsFinalized = false, StartTime = new DateTime(2022, 01, 01) }
+            }
+        };
+
+        _repository.Setup(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>())).ReturnsAsync(pollutedLocation);
+
+        var result = await _validator.ValidateAsync(input);
+
+        _repository.Verify(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>()), Times.Once);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Errors, Is.Empty);
+        Assert.That(result.IsValid, Is.True);
+    }
+
+    [Test]
+    public async Task ValidInputWithRepositoryCall_EventAlreadyFinalized_ShouldFailValidation()
+    {
+        var input = new CleaningEventFinalizeRequest
+        {
+            Id = Guid.NewGuid(),
+            NewProgress = 20
+        };
+
+        var pollutedLocation = new PollutedLocation
+        {
+            Progress = 15,
+            Events = new List<CleaningEvent>
+            {
+                new() { Id = (Guid)input.Id, IsFinalized = true, StartTime = new DateTime(2022, 01, 01) }
+            }
+        };
+
+        _repository.Setup(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>())).ReturnsAsync(pollutedLocation);
+
+        var result = await _validator.ValidateAsync(input);
+
+        _repository.Verify(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>()), Times.Once);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Errors, Has.Count.EqualTo(1));
+        Assert.That(result.IsValid, Is.False);
+    }
+
+    [Test]
+    public async Task ValidInputWithRepositoryCall_StartTimeInTheFuture_ShouldFailValidation()
+    {
+        var input = new CleaningEventFinalizeRequest
+        {
+            Id = Guid.NewGuid(),
+            NewProgress = 20
+        };
+
+        var pollutedLocation = new PollutedLocation
+        {
+            Progress = 15,
+            Events = new List<CleaningEvent>
+            {
+                new() { Id = (Guid)input.Id, IsFinalized = false, StartTime = DateTime.UtcNow + TimeSpan.FromDays(1) }
+            }
+        };
+
+        _repository.Setup(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>())).ReturnsAsync(pollutedLocation);
+
+        var result = await _validator.ValidateAsync(input);
+
+        _repository.Verify(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>()), Times.Once);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Errors, Has.Count.EqualTo(1));
+        Assert.That(result.IsValid, Is.False);
+    }
+
+    [Test]
+    public async Task ValidInputWithRepositoryCall_ProgressLowerThanPollutedLocations_ShouldFailValidation()
+    {
+        var input = new CleaningEventFinalizeRequest
+        {
+            Id = Guid.NewGuid(),
+            NewProgress = 20
+        };
+
+        var pollutedLocation = new PollutedLocation
+        {
+            Progress = 21,
+            Events = new List<CleaningEvent>
+            {
+                new() { Id = (Guid)input.Id, IsFinalized = false, StartTime = new DateTime(2022, 01, 01) }
+            }
+        };
+
+        _repository.Setup(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>())).ReturnsAsync(pollutedLocation);
+
+        var result = await _validator.ValidateAsync(input);
+
+        _repository.Verify(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>()), Times.Once);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Errors, Has.Count.EqualTo(1));
+        Assert.That(result.IsValid, Is.False);
+    }
+
+    [Test]
+    public async Task ValidInputWithRepositoryCall_RepositoryThrows_NoErrorsReturned()
+    {
+        var input = new CleaningEventFinalizeRequest
+        {
+            Id = Guid.NewGuid(),
+            NewProgress = 20
+        };
+
+        _repository.Setup(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>())).Throws<Exception>();
+
+        var result = await _validator.ValidateAsync(input);
+
+        _repository.Verify(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>()), Times.Once);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Errors, Is.Empty);
+        Assert.That(result.IsValid, Is.True);
+    }
+}

--- a/Apsitvarkom.UnitTests/ModelActions/Validation/CleaningEventFinalizeRequestValidationTests.cs
+++ b/Apsitvarkom.UnitTests/ModelActions/Validation/CleaningEventFinalizeRequestValidationTests.cs
@@ -25,7 +25,7 @@ public class CleaningEventFinalizeRequestValidationTests
         new()
         {
             Id = Guid.NewGuid(),
-            NewProgress = 12
+            NewProgress = 50
         }
     };
 
@@ -74,18 +74,13 @@ public class CleaningEventFinalizeRequestValidationTests
     [Test]
     public async Task ValidInputWithRepositoryCall_FinalizeAvailable_ShouldSucceedValidation()
     {
-        var input = new CleaningEventFinalizeRequest
-        {
-            Id = Guid.NewGuid(),
-            NewProgress = 20
-        };
-
+        var input = ValidCleaningEventFinalizeRequests.First();
         var pollutedLocation = new PollutedLocation
         {
-            Progress = 15,
+            Progress = (int)input.NewProgress! - 5,
             Events = new List<CleaningEvent>
             {
-                new() { Id = (Guid)input.Id, IsFinalized = false, StartTime = new DateTime(2022, 01, 01) }
+                new() { Id = (Guid)input.Id!, IsFinalized = false, StartTime = new DateTime(2022, 01, 01) }
             }
         };
 
@@ -103,18 +98,13 @@ public class CleaningEventFinalizeRequestValidationTests
     [Test]
     public async Task ValidInputWithRepositoryCall_EventAlreadyFinalized_ShouldFailValidation()
     {
-        var input = new CleaningEventFinalizeRequest
-        {
-            Id = Guid.NewGuid(),
-            NewProgress = 20
-        };
-
+        var input = ValidCleaningEventFinalizeRequests.First();
         var pollutedLocation = new PollutedLocation
         {
-            Progress = 15,
+            Progress = (int)input.NewProgress! - 5,
             Events = new List<CleaningEvent>
             {
-                new() { Id = (Guid)input.Id, IsFinalized = true, StartTime = new DateTime(2022, 01, 01) }
+                new() { Id = (Guid)input.Id!, IsFinalized = true, StartTime = new DateTime(2022, 01, 01) }
             }
         };
 
@@ -132,18 +122,13 @@ public class CleaningEventFinalizeRequestValidationTests
     [Test]
     public async Task ValidInputWithRepositoryCall_StartTimeInTheFuture_ShouldFailValidation()
     {
-        var input = new CleaningEventFinalizeRequest
-        {
-            Id = Guid.NewGuid(),
-            NewProgress = 20
-        };
-
+        var input = ValidCleaningEventFinalizeRequests.First();
         var pollutedLocation = new PollutedLocation
         {
-            Progress = 15,
+            Progress = (int)input.NewProgress! - 5,
             Events = new List<CleaningEvent>
             {
-                new() { Id = (Guid)input.Id, IsFinalized = false, StartTime = DateTime.UtcNow + TimeSpan.FromDays(1) }
+                new() { Id = (Guid)input.Id!, IsFinalized = false, StartTime = DateTime.UtcNow + TimeSpan.FromDays(1) }
             }
         };
 
@@ -161,18 +146,13 @@ public class CleaningEventFinalizeRequestValidationTests
     [Test]
     public async Task ValidInputWithRepositoryCall_ProgressLowerThanPollutedLocations_ShouldFailValidation()
     {
-        var input = new CleaningEventFinalizeRequest
-        {
-            Id = Guid.NewGuid(),
-            NewProgress = 20
-        };
-
+        var input = ValidCleaningEventFinalizeRequests.First();
         var pollutedLocation = new PollutedLocation
         {
-            Progress = 21,
+            Progress = (int)input.NewProgress! + 5,
             Events = new List<CleaningEvent>
             {
-                new() { Id = (Guid)input.Id, IsFinalized = false, StartTime = new DateTime(2022, 01, 01) }
+                new() { Id = (Guid)input.Id!, IsFinalized = false, StartTime = new DateTime(2022, 01, 01) }
             }
         };
 
@@ -190,15 +170,9 @@ public class CleaningEventFinalizeRequestValidationTests
     [Test]
     public async Task ValidInputWithRepositoryCall_RepositoryThrows_NoErrorsReturned()
     {
-        var input = new CleaningEventFinalizeRequest
-        {
-            Id = Guid.NewGuid(),
-            NewProgress = 20
-        };
-
         _repository.Setup(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>())).Throws<Exception>();
 
-        var result = await _validator.ValidateAsync(input);
+        var result = await _validator.ValidateAsync(ValidCleaningEventFinalizeRequests.First());
 
         _repository.Verify(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>()), Times.Once);
 

--- a/Apsitvarkom.UnitTests/ModelActions/Validation/CleaningEventUpdateRequestValidationTests.cs
+++ b/Apsitvarkom.UnitTests/ModelActions/Validation/CleaningEventUpdateRequestValidationTests.cs
@@ -82,13 +82,7 @@ public class CleaningEventUpdateRequestValidationTests
     [Test]
     public async Task ValidInputWithRepositoryCall_UpdateAvailable_ShouldSucceedValidation()
     {
-        var input = new CleaningEventUpdateRequest
-        {
-            Id = Guid.NewGuid(),
-            StartTime = DateTime.Parse("2077-03-12T10:11:12Z"),
-            Notes = "boop"
-        };
-
+        var input = ValidCleaningEventUpdateRequests.First();
         var cleaningEvent = new CleaningEvent
         {
             Id = (Guid)input.Id!,
@@ -109,13 +103,7 @@ public class CleaningEventUpdateRequestValidationTests
     [Test]
     public async Task ValidInputWithRepositoryCall_UpdateUnavailable_ShouldFailValidation()
     {
-        var input = new CleaningEventUpdateRequest
-        {
-            Id = Guid.NewGuid(),
-            StartTime = DateTime.Parse("2077-03-12T10:11:12Z"),
-            Notes = "boop"
-        };
-
+        var input = ValidCleaningEventUpdateRequests.First();
         var cleaningEvent = new CleaningEvent
         {
             Id = (Guid)input.Id!,
@@ -136,16 +124,9 @@ public class CleaningEventUpdateRequestValidationTests
     [Test]
     public async Task ValidInputWithRepositoryCall_RepositoryThrows_NoErrorsReturned()
     {
-        var input = new CleaningEventUpdateRequest
-        {
-            Id = Guid.NewGuid(),
-            StartTime = DateTime.Parse("2077-03-12T10:11:12Z"),
-            Notes = "boop"
-        };
-
         _repository.Setup(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<CleaningEvent, bool>>>())).Throws<Exception>();
 
-        var result = await _validator.ValidateAsync(input);
+        var result = await _validator.ValidateAsync(ValidCleaningEventUpdateRequests.First());
 
         _repository.Verify(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<CleaningEvent, bool>>>()), Times.Once);
 

--- a/Apsitvarkom.UnitTests/ModelActions/Validation/CleaningEventUpdateRequestValidationTests.cs
+++ b/Apsitvarkom.UnitTests/ModelActions/Validation/CleaningEventUpdateRequestValidationTests.cs
@@ -1,7 +1,8 @@
-﻿using Apsitvarkom.Models.Public;
+﻿using Apsitvarkom.ModelActions.Validation;
+using Apsitvarkom.Models.Public;
 using FluentValidation;
 
-namespace Apsitvarkom.UnitTests.Models.Validation;
+namespace Apsitvarkom.UnitTests.ModelActions.Validation;
 
 public class CleaningEventUpdateRequestValidationTests
 {
@@ -62,7 +63,7 @@ public class CleaningEventUpdateRequestValidationTests
         var result = await Validator.ValidateAsync(input);
 
         Assert.That(result, Is.Not.Null);
-        Assert.That(result.Errors.Count, Is.EqualTo(1));
+        Assert.That(result.Errors, Has.Count.EqualTo(1));
         Assert.That(result.IsValid, Is.False);
     }
 }

--- a/Apsitvarkom.UnitTests/ModelActions/Validation/CoordinatesCreateRequestValidationTests.cs
+++ b/Apsitvarkom.UnitTests/ModelActions/Validation/CoordinatesCreateRequestValidationTests.cs
@@ -1,13 +1,14 @@
-﻿using Apsitvarkom.Models.Public;
+﻿using Apsitvarkom.ModelActions.Validation;
+using Apsitvarkom.Models.Public;
 using FluentValidation;
 
-namespace Apsitvarkom.UnitTests.Models.Validation;
+namespace Apsitvarkom.UnitTests.ModelActions.Validation;
 
-public class CoordinatesResponseValidationTests
+public class CoordinatesCreateRequestValidationTests
 {
-    private static readonly IValidator<CoordinatesResponse> Validator = new CoordinatesResponseValidator();
+    private static readonly IValidator<CoordinatesCreateRequest> Validator = new CoordinatesCreateRequestValidator();
 
-    private static readonly CoordinatesResponse[] ValidCoordinateResponses =
+    private static readonly CoordinatesCreateRequest[] ValidCoordinatesCreateRequest =
     {
         new()
         {
@@ -21,8 +22,17 @@ public class CoordinatesResponseValidationTests
         },
     };
 
-    private static readonly CoordinatesResponse[] InvalidCoordinateResponses =
+    private static readonly CoordinatesCreateRequest[] InvalidCoordinatesCreateRequest =
     {
+        new(),
+        new()
+        {
+            Latitude = null,
+        },
+        new()
+        {
+            Longitude = null,
+        },
         new()
         {
             Latitude = -91,
@@ -46,8 +56,8 @@ public class CoordinatesResponseValidationTests
     };
 
     [Test]
-    [TestCaseSource(nameof(ValidCoordinateResponses))]
-    public async Task ValidInputShouldSucceedValidation(CoordinatesResponse input)
+    [TestCaseSource(nameof(ValidCoordinatesCreateRequest))]
+    public async Task ValidInputShouldSucceedValidation(CoordinatesCreateRequest input)
     {
         var result = await Validator.ValidateAsync(input);
 
@@ -57,8 +67,8 @@ public class CoordinatesResponseValidationTests
     }
 
     [Test]
-    [TestCaseSource(nameof(InvalidCoordinateResponses))]
-    public async Task InvalidInputShouldFailValidation(CoordinatesResponse input)
+    [TestCaseSource(nameof(InvalidCoordinatesCreateRequest))]
+    public async Task InvalidInputShouldFailValidation(CoordinatesCreateRequest input)
     {
         var result = await Validator.ValidateAsync(input);
 

--- a/Apsitvarkom.UnitTests/ModelActions/Validation/CoordinatesResponseValidationTests.cs
+++ b/Apsitvarkom.UnitTests/ModelActions/Validation/CoordinatesResponseValidationTests.cs
@@ -1,13 +1,14 @@
-﻿using Apsitvarkom.Models.Public;
+﻿using Apsitvarkom.ModelActions.Validation;
+using Apsitvarkom.Models.Public;
 using FluentValidation;
 
-namespace Apsitvarkom.UnitTests.Models.Validation;
+namespace Apsitvarkom.UnitTests.ModelActions.Validation;
 
-public class CoordinatesCreateRequestValidationTests
+public class CoordinatesResponseValidationTests
 {
-    private static readonly IValidator<CoordinatesCreateRequest> Validator = new CoordinatesCreateRequestValidator();
+    private static readonly IValidator<CoordinatesResponse> Validator = new CoordinatesResponseValidator();
 
-    private static readonly CoordinatesCreateRequest[] ValidCoordinatesCreateRequest =
+    private static readonly CoordinatesResponse[] ValidCoordinateResponses =
     {
         new()
         {
@@ -21,17 +22,8 @@ public class CoordinatesCreateRequestValidationTests
         },
     };
 
-    private static readonly CoordinatesCreateRequest[] InvalidCoordinatesCreateRequest =
+    private static readonly CoordinatesResponse[] InvalidCoordinateResponses =
     {
-        new(),
-        new()
-        {
-            Latitude = null,
-        },
-        new()
-        {
-            Longitude = null,
-        },
         new()
         {
             Latitude = -91,
@@ -55,8 +47,8 @@ public class CoordinatesCreateRequestValidationTests
     };
 
     [Test]
-    [TestCaseSource(nameof(ValidCoordinatesCreateRequest))]
-    public async Task ValidInputShouldSucceedValidation(CoordinatesCreateRequest input)
+    [TestCaseSource(nameof(ValidCoordinateResponses))]
+    public async Task ValidInputShouldSucceedValidation(CoordinatesResponse input)
     {
         var result = await Validator.ValidateAsync(input);
 
@@ -66,8 +58,8 @@ public class CoordinatesCreateRequestValidationTests
     }
 
     [Test]
-    [TestCaseSource(nameof(InvalidCoordinatesCreateRequest))]
-    public async Task InvalidInputShouldFailValidation(CoordinatesCreateRequest input)
+    [TestCaseSource(nameof(InvalidCoordinateResponses))]
+    public async Task InvalidInputShouldFailValidation(CoordinatesResponse input)
     {
         var result = await Validator.ValidateAsync(input);
 

--- a/Apsitvarkom.UnitTests/ModelActions/Validation/ObjectIdentifyRequestValidationTests.cs
+++ b/Apsitvarkom.UnitTests/ModelActions/Validation/ObjectIdentifyRequestValidationTests.cs
@@ -1,7 +1,8 @@
-﻿using Apsitvarkom.Models.Public;
+﻿using Apsitvarkom.ModelActions.Validation;
+using Apsitvarkom.Models.Public;
 using FluentValidation;
 
-namespace Apsitvarkom.UnitTests.Models.Validation;
+namespace Apsitvarkom.UnitTests.ModelActions.Validation;
 
 public class ObjectIdentifyRequestValidationTests
 {
@@ -45,7 +46,7 @@ public class ObjectIdentifyRequestValidationTests
         var result = await Validator.ValidateAsync(input);
 
         Assert.That(result, Is.Not.Null);
-        Assert.That(result.Errors.Count, Is.EqualTo(1));
+        Assert.That(result.Errors, Has.Count.EqualTo(1));
         Assert.That(result.IsValid, Is.False);
     }
 }

--- a/Apsitvarkom.UnitTests/ModelActions/Validation/PollutedLocationCreateRequestValidationTests.cs
+++ b/Apsitvarkom.UnitTests/ModelActions/Validation/PollutedLocationCreateRequestValidationTests.cs
@@ -1,8 +1,9 @@
-﻿using Apsitvarkom.Models;
+﻿using Apsitvarkom.ModelActions.Validation;
+using Apsitvarkom.Models;
 using Apsitvarkom.Models.Public;
 using FluentValidation;
 
-namespace Apsitvarkom.UnitTests.Models.Validation;
+namespace Apsitvarkom.UnitTests.ModelActions.Validation;
 
 public class PollutedLocationCreateRequestValidationTests
 {
@@ -105,7 +106,7 @@ public class PollutedLocationCreateRequestValidationTests
 
         Assert.That(result, Is.Not.Null);
         // Only 1 thing must error in the invalid input
-        Assert.That(result.Errors.Count, Is.EqualTo(1));
+        Assert.That(result.Errors, Has.Count.EqualTo(1));
         Assert.That(result.IsValid, Is.False);
     }
 }

--- a/Apsitvarkom.UnitTests/ModelActions/Validation/PollutedLocationResponseValidationTests.cs
+++ b/Apsitvarkom.UnitTests/ModelActions/Validation/PollutedLocationResponseValidationTests.cs
@@ -1,8 +1,9 @@
-﻿using Apsitvarkom.Models;
+﻿using Apsitvarkom.ModelActions.Validation;
+using Apsitvarkom.Models;
 using Apsitvarkom.Models.Public;
 using FluentValidation;
 
-namespace Apsitvarkom.UnitTests.Models.Validation;
+namespace Apsitvarkom.UnitTests.ModelActions.Validation;
 
 public class PollutedLocationResponseValidationTests
 {
@@ -158,7 +159,7 @@ public class PollutedLocationResponseValidationTests
 
         Assert.That(result, Is.Not.Null);
         // Only 1 thing must error in the invalid input
-        Assert.That(result.Errors.Count, Is.EqualTo(1));
+        Assert.That(result.Errors, Has.Count.EqualTo(1));
         Assert.That(result.IsValid, Is.False);
     }
 }

--- a/Apsitvarkom.UnitTests/ModelActions/Validation/PollutedLocationUpdateRequestValidationTests.cs
+++ b/Apsitvarkom.UnitTests/ModelActions/Validation/PollutedLocationUpdateRequestValidationTests.cs
@@ -91,13 +91,7 @@ public class PollutedLocationUpdateRequestValidatorTests
     [Test]
     public async Task ValidInputWithRepositoryCall_UpdateAvailable_ShouldSucceedValidation()
     {
-        var input = new PollutedLocationUpdateRequest
-        {
-            Id = Guid.NewGuid(),
-            Radius = 12,
-            Severity = PollutedLocation.SeverityLevel.Low,
-        };
-
+        var input = ValidPollutedLocationUpdateRequests.First();
         var pollutedLocation = new PollutedLocation
         {
             Progress = 12
@@ -117,13 +111,7 @@ public class PollutedLocationUpdateRequestValidatorTests
     [Test]
     public async Task ValidInputWithRepositoryCall_UpdateUnavailable_ShouldFailValidation()
     {
-        var input = new PollutedLocationUpdateRequest
-        {
-            Id = Guid.NewGuid(),
-            Radius = 12,
-            Severity = PollutedLocation.SeverityLevel.Low,
-        };
-
+        var input = ValidPollutedLocationUpdateRequests.First();
         var pollutedLocation = new PollutedLocation
         {
             Progress = 100
@@ -143,16 +131,9 @@ public class PollutedLocationUpdateRequestValidatorTests
     [Test]
     public async Task ValidInputWithRepositoryCall_RepositoryThrows_NoErrorsReturned()
     {
-        var input = new PollutedLocationUpdateRequest
-        {
-            Id = Guid.NewGuid(),
-            Radius = 12,
-            Severity = PollutedLocation.SeverityLevel.Low,
-        };
-
         _repository.Setup(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>())).Throws<Exception>();
 
-        var result = await _validator.ValidateAsync(input);
+        var result = await _validator.ValidateAsync(ValidPollutedLocationUpdateRequests.First());
 
         _repository.Verify(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>()), Times.Once);
 

--- a/Apsitvarkom.UnitTests/ModelActions/Validation/PollutedLocationUpdateRequestValidationTests.cs
+++ b/Apsitvarkom.UnitTests/ModelActions/Validation/PollutedLocationUpdateRequestValidationTests.cs
@@ -1,13 +1,24 @@
-﻿using Apsitvarkom.ModelActions.Validation;
+﻿using Apsitvarkom.DataAccess;
+using Apsitvarkom.ModelActions.Validation;
 using Apsitvarkom.Models;
 using Apsitvarkom.Models.Public;
 using FluentValidation;
+using Moq;
+using System.Linq.Expressions;
 
 namespace Apsitvarkom.UnitTests.ModelActions.Validation;
 
 public class PollutedLocationUpdateRequestValidatorTests
 {
-    private static readonly IValidator<PollutedLocationUpdateRequest> Validator = new PollutedLocationUpdateRequestValidator();
+    private IValidator<PollutedLocationUpdateRequest> _validator;
+    private Mock<IPollutedLocationRepository> _repository;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repository = new Mock<IPollutedLocationRepository>();
+        _validator = new PollutedLocationUpdateRequestValidator(_repository.Object);
+    }
 
     private static readonly PollutedLocationUpdateRequest[] ValidPollutedLocationUpdateRequests =
     {
@@ -59,7 +70,7 @@ public class PollutedLocationUpdateRequestValidatorTests
     [TestCaseSource(nameof(ValidPollutedLocationUpdateRequests))]
     public async Task ValidInputShouldSucceedValidation(PollutedLocationUpdateRequest input)
     {
-        var result = await Validator.ValidateAsync(input);
+        var result = await _validator.ValidateAsync(input);
 
         Assert.That(result, Is.Not.Null);
         Assert.That(result.Errors, Is.Empty);
@@ -70,10 +81,83 @@ public class PollutedLocationUpdateRequestValidatorTests
     [TestCaseSource(nameof(InvalidPollutedLocationUpdateRequests))]
     public async Task InvalidInputShouldFailValidation(PollutedLocationUpdateRequest input)
     {
-        var result = await Validator.ValidateAsync(input);
+        var result = await _validator.ValidateAsync(input);
 
         Assert.That(result, Is.Not.Null);
         Assert.That(result.Errors, Has.Count.EqualTo(1));
         Assert.That(result.IsValid, Is.False);
+    }
+
+    [Test]
+    public async Task ValidInputWithRepositoryCall_UpdateAvailable_ShouldSucceedValidation()
+    {
+        var input = new PollutedLocationUpdateRequest
+        {
+            Id = Guid.NewGuid(),
+            Radius = 12,
+            Severity = PollutedLocation.SeverityLevel.Low,
+        };
+
+        var pollutedLocation = new PollutedLocation
+        {
+            Progress = 12
+        };
+
+        _repository.Setup(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>())).ReturnsAsync(pollutedLocation);
+
+        var result = await _validator.ValidateAsync(input);
+
+        _repository.Verify(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>()), Times.Once);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Errors, Is.Empty);
+        Assert.That(result.IsValid, Is.True);
+    }
+
+    [Test]
+    public async Task ValidInputWithRepositoryCall_UpdateUnavailable_ShouldFailValidation()
+    {
+        var input = new PollutedLocationUpdateRequest
+        {
+            Id = Guid.NewGuid(),
+            Radius = 12,
+            Severity = PollutedLocation.SeverityLevel.Low,
+        };
+
+        var pollutedLocation = new PollutedLocation
+        {
+            Progress = 100
+        };
+
+        _repository.Setup(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>())).ReturnsAsync(pollutedLocation);
+
+        var result = await _validator.ValidateAsync(input);
+
+        _repository.Verify(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>()), Times.Once);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Errors, Has.Count.EqualTo(1));
+        Assert.That(result.IsValid, Is.False);
+    }
+
+    [Test]
+    public async Task ValidInputWithRepositoryCall_RepositoryThrows_NoErrorsReturned()
+    {
+        var input = new PollutedLocationUpdateRequest
+        {
+            Id = Guid.NewGuid(),
+            Radius = 12,
+            Severity = PollutedLocation.SeverityLevel.Low,
+        };
+
+        _repository.Setup(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>())).Throws<Exception>();
+
+        var result = await _validator.ValidateAsync(input);
+
+        _repository.Verify(x => x.GetByPropertyAsync(It.IsAny<Expression<Func<PollutedLocation, bool>>>()), Times.Once);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Errors, Is.Empty);
+        Assert.That(result.IsValid, Is.True);
     }
 }

--- a/Apsitvarkom.UnitTests/ModelActions/Validation/PollutedLocationUpdateRequestValidationTests.cs
+++ b/Apsitvarkom.UnitTests/ModelActions/Validation/PollutedLocationUpdateRequestValidationTests.cs
@@ -1,8 +1,9 @@
-﻿using Apsitvarkom.Models.Public;
+﻿using Apsitvarkom.ModelActions.Validation;
 using Apsitvarkom.Models;
+using Apsitvarkom.Models.Public;
 using FluentValidation;
 
-namespace Apsitvarkom.UnitTests.Models.Validation;
+namespace Apsitvarkom.UnitTests.ModelActions.Validation;
 
 public class PollutedLocationUpdateRequestValidatorTests
 {
@@ -72,7 +73,7 @@ public class PollutedLocationUpdateRequestValidatorTests
         var result = await Validator.ValidateAsync(input);
 
         Assert.That(result, Is.Not.Null);
-        Assert.That(result.Errors.Count, Is.EqualTo(1));
+        Assert.That(result.Errors, Has.Count.EqualTo(1));
         Assert.That(result.IsValid, Is.False);
     }
 }

--- a/Apsitvarkom.UnitTests/Models/Mapping/CleaningEventMappingTests.cs
+++ b/Apsitvarkom.UnitTests/Models/Mapping/CleaningEventMappingTests.cs
@@ -83,6 +83,33 @@ public class CleaningEventMappingTests
             Assert.That(mappedEvent.StartTime, Is.EqualTo(updateModel.StartTime));
         });
     }
+
+    [Test]
+    public void CleaningEventUpdateRequestToPollutedLocation_NotesNull_NotesSetToNull()
+    {
+        var businessLogicObject = new CleaningEvent
+        {
+            Id = Guid.NewGuid(),
+            PollutedLocationId = Guid.NewGuid(),
+            StartTime = DateTime.Parse("2077-05-12T10:11:12Z"),
+            Notes = "L"
+        };
+
+        var updateModel = new CleaningEventUpdateRequest
+        {
+            Id = businessLogicObject.Id,
+            StartTime = DateTime.Parse("2077-03-12T10:11:12Z"),
+        };
+
+        var mappedEvent = _mapper.Map(updateModel, businessLogicObject);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(mappedEvent.Id, Is.EqualTo(businessLogicObject.Id));
+            Assert.That(mappedEvent.Notes, Is.Null);
+            Assert.That(mappedEvent.StartTime, Is.EqualTo(updateModel.StartTime));
+        });
+    }
     #endregion
 
     #region Response mappings

--- a/Apsitvarkom.UnitTests/Models/Mapping/PollutedLocationMappingTests.cs
+++ b/Apsitvarkom.UnitTests/Models/Mapping/PollutedLocationMappingTests.cs
@@ -112,7 +112,6 @@ public class PollutedLocationMappingTests
             Id = businessLogicObject.Id,
             Radius = 7,
             Severity = PollutedLocation.SeverityLevel.Moderate,
-            Progress = 16,
             Notes = "testt"
         };
 
@@ -127,7 +126,7 @@ public class PollutedLocationMappingTests
             Assert.That(mappedLocation.Spotted, Is.EqualTo(businessLogicObject.Spotted));
             Assert.That(mappedLocation.Id, Is.EqualTo(businessLogicObject.Id));
             Assert.That(mappedLocation.Notes, Is.EqualTo(updateModel.Notes));
-            Assert.That(mappedLocation.Progress, Is.EqualTo(updateModel.Progress));
+            Assert.That(mappedLocation.Progress, Is.EqualTo(businessLogicObject.Progress));
             Assert.That(mappedLocation.Radius, Is.EqualTo(updateModel.Radius));
             Assert.That(mappedLocation.Severity, Is.EqualTo(updateModel.Severity));
         });

--- a/Apsitvarkom.UnitTests/Models/Mapping/PollutedLocationMappingTests.cs
+++ b/Apsitvarkom.UnitTests/Models/Mapping/PollutedLocationMappingTests.cs
@@ -133,7 +133,7 @@ public class PollutedLocationMappingTests
     }
 
     [Test]
-    public void PollutedLocationUpdateRequestToPollutedLocation_SomePropertiesNull_KeepsBusinessObjectValues()
+    public void PollutedLocationUpdateRequestToPollutedLocation_NotesNull_NotesSetToNull()
     {
         var businessLogicObject = new PollutedLocation
         {
@@ -171,7 +171,7 @@ public class PollutedLocationMappingTests
             Assert.That(mappedLocation.Location.Title.Lithuanian, Is.EqualTo(businessLogicObject.Location.Title.Lithuanian));
             Assert.That(mappedLocation.Spotted, Is.EqualTo(businessLogicObject.Spotted));
             Assert.That(mappedLocation.Id, Is.EqualTo(businessLogicObject.Id));
-            Assert.That(mappedLocation.Notes, Is.EqualTo(businessLogicObject.Notes));
+            Assert.That(mappedLocation.Notes, Is.Null);
             Assert.That(mappedLocation.Progress, Is.EqualTo(businessLogicObject.Progress));
             Assert.That(mappedLocation.Radius, Is.EqualTo(updateModel.Radius));
             Assert.That(mappedLocation.Severity, Is.EqualTo(updateModel.Severity));

--- a/Apsitvarkom.UnitTests/Models/Validation/CleaningEventUpdateRequestValidationTests.cs
+++ b/Apsitvarkom.UnitTests/Models/Validation/CleaningEventUpdateRequestValidationTests.cs
@@ -31,6 +31,12 @@ public class CleaningEventUpdateRequestValidationTests
         },
         new()
         { 
+            // Missing StartTime
+            Id = Guid.NewGuid(),
+            Notes = "boop"
+        },
+        new()
+        { 
             // Invalid StartTime
             Id = Guid.NewGuid(),
             StartTime = DateTime.Parse("2007-03-12T10:11:12Z"),

--- a/Apsitvarkom.UnitTests/Models/Validation/PollutedLocationUpdateRequestValidationTests.cs
+++ b/Apsitvarkom.UnitTests/Models/Validation/PollutedLocationUpdateRequestValidationTests.cs
@@ -34,6 +34,18 @@ public class PollutedLocationUpdateRequestValidatorTests
             Severity = PollutedLocation.SeverityLevel.High,
         },
         new()
+        {
+            // Missing radius
+            Id = Guid.NewGuid(),
+            Severity = PollutedLocation.SeverityLevel.Low,
+        },
+        new()
+        {
+            // Missing severity
+            Id = Guid.NewGuid(),
+            Radius = 1,
+        },
+        new()
         { 
             // Invalid radius
             Id = Guid.NewGuid(),

--- a/Apsitvarkom.UnitTests/Models/Validation/PollutedLocationUpdateRequestValidationTests.cs
+++ b/Apsitvarkom.UnitTests/Models/Validation/PollutedLocationUpdateRequestValidationTests.cs
@@ -15,7 +15,6 @@ public class PollutedLocationUpdateRequestValidatorTests
             Id = Guid.NewGuid(),
             Radius = 5,
             Severity = PollutedLocation.SeverityLevel.Moderate,
-            Progress = 41,
             Notes = "Prisoners test."
         },
         new()
@@ -23,7 +22,6 @@ public class PollutedLocationUpdateRequestValidatorTests
             Id = Guid.NewGuid(),
             Radius = 12,
             Severity = PollutedLocation.SeverityLevel.Low,
-            Progress = 13,
         },
     };
 
@@ -32,23 +30,13 @@ public class PollutedLocationUpdateRequestValidatorTests
         new()
         {
              // Missing id
-            Progress = 1,
             Radius = 1,
             Severity = PollutedLocation.SeverityLevel.High,
         },
         new()
         { 
-            // Invalid progress
-            Id = Guid.NewGuid(),
-            Progress = 101,
-            Radius = 2,
-            Severity = PollutedLocation.SeverityLevel.Low,
-        },
-        new()
-        { 
             // Invalid radius
             Id = Guid.NewGuid(),
-            Progress = 11,
             Radius = 0,
             Severity = PollutedLocation.SeverityLevel.Low,
         },

--- a/Apsitvarkom.sln
+++ b/Apsitvarkom.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Apsitvarkom.Configuration",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Apsitvarkom.IntegrationTests", "Apsitvarkom.IntegrationTests\Apsitvarkom.IntegrationTests.csproj", "{3FD00F6F-CE03-471C-B057-85B501A5D743}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apsitvarkom.ModelActions", "Apsitvarkom.ModelActions\Apsitvarkom.ModelActions.csproj", "{51998D7B-E5D3-42FF-97A0-456C40E7AF57}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{3FD00F6F-CE03-471C-B057-85B501A5D743}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3FD00F6F-CE03-471C-B057-85B501A5D743}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3FD00F6F-CE03-471C-B057-85B501A5D743}.Release|Any CPU.Build.0 = Release|Any CPU
+		{51998D7B-E5D3-42FF-97A0-456C40E7AF57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{51998D7B-E5D3-42FF-97A0-456C40E7AF57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{51998D7B-E5D3-42FF-97A0-456C40E7AF57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{51998D7B-E5D3-42FF-97A0-456C40E7AF57}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## What was done

<!-- Describe in points what was done for easier overview -->

- Moved mapping and validation to a separate project to avoid circular project dependency.
- Added extra validator rules for `PollutedLocationUpdateValidator`, `CleaningEventUpdateValidator`, `CleaningEventCreateValidator`
- Created a new `/Finalize/` endpoint, which should be used whenever the event is finished and we want to report the progress done.
- Introduced a `Status` property for `CleaningEvent`, which now stores the indicator whether the cleaning event's results have been already reported/finalized. 

Closes #126 + extra

Related item: #136 