### PR TITLE
Swagger descriptions added for uncovered fluent validation rules

### DIFF
--- a/Apsitvarkom.Api/Apsitvarkom.Api.csproj
+++ b/Apsitvarkom.Api/Apsitvarkom.Api.csproj
@@ -5,6 +5,15 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>e0e24a99-2f07-4134-a8ca-1b990f6e1a1e</UserSecretsId>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Apsitvarkom.Api/Controllers/CleaningEventController.cs
+++ b/Apsitvarkom.Api/Controllers/CleaningEventController.cs
@@ -88,6 +88,8 @@ public class CleaningEventController : ControllerBase
         return Ok(mappedEvent);
     }
 
+    /// <param name="cleaningEventCreateRequest">The `Cleaning Event` to be created has to reference a `Polluted Location` whose progress value is less than 100
+    /// and which has no active `Cleaning Event`s.</param>
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(List<string>))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -133,6 +135,7 @@ public class CleaningEventController : ControllerBase
         return CreatedAtAction(nameof(GetById), new { response.Id }, response);
     }
 
+    /// <param name="cleaningEventUpdateRequest">The `Cleaning Event` to be updated has to be not yet finalized.</param>
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(List<string>))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -173,6 +176,8 @@ public class CleaningEventController : ControllerBase
         return Ok(response);
     }
 
+    /// <param name="cleaningEventFinalizeRequest">The `Cleaning Event` to be finalized has to be already finished but not yet finalized
+    /// and the new progress value should be higher than the currently referenced `Polluted Location`'s progress value.</param>
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(List<string>))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/Apsitvarkom.Api/Controllers/CleaningEventController.cs
+++ b/Apsitvarkom.Api/Controllers/CleaningEventController.cs
@@ -88,8 +88,8 @@ public class CleaningEventController : ControllerBase
         return Ok(mappedEvent);
     }
 
-    /// <param name="cleaningEventCreateRequest">The `Cleaning Event` to be created has to reference a `Polluted Location` whose progress value is less than 100
-    /// and which has no active `Cleaning Event`s.</param>
+    /// <param name="cleaningEventCreateRequest">The `Cleaning Event` to be created has to have a Start Time value in the future, as well as
+    /// reference a `Polluted Location` whose progress value is less than 100 and which has no active `Cleaning Event`s.</param>
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(List<string>))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -135,7 +135,7 @@ public class CleaningEventController : ControllerBase
         return CreatedAtAction(nameof(GetById), new { response.Id }, response);
     }
 
-    /// <param name="cleaningEventUpdateRequest">The `Cleaning Event` to be updated has to be not yet finalized.</param>
+    /// <param name="cleaningEventUpdateRequest">The `Cleaning Event` to be updated has to be not yet finalized as well as have a Start Time value in the future.</param>
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(List<string>))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/Apsitvarkom.Api/Controllers/PollutedLocationController.cs
+++ b/Apsitvarkom.Api/Controllers/PollutedLocationController.cs
@@ -159,6 +159,7 @@ public class PollutedLocationController : ControllerBase
         return CreatedAtAction(nameof(GetById), new { response.Id }, response);
     }
 
+    /// <param name="pollutedLocationUpdateRequest">The progress of the `Polluted Location` to be updated has to be not equal to 100.</param>
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(List<string>))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/Apsitvarkom.Api/Program.cs
+++ b/Apsitvarkom.Api/Program.cs
@@ -9,6 +9,7 @@ using Apsitvarkom.ModelActions.Mapping;
 using Apsitvarkom.ModelActions.Validation;
 using Apsitvarkom.Models;
 using Apsitvarkom.Api.Middleware;
+using System.Reflection;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -31,6 +32,9 @@ builder.Services.AddSwaggerGen(c =>
             }
         }
      );
+    var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+    var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+    c.IncludeXmlComments(xmlPath);
 });
 
 builder.Services

--- a/Apsitvarkom.Api/Program.cs
+++ b/Apsitvarkom.Api/Program.cs
@@ -22,7 +22,7 @@ builder.Services.AddSwaggerGen(c =>
     c.SwaggerDoc("v1",
         new OpenApiInfo
         {
-            Title = "Apsitvarkom REST API",
+            Title = "Apsitvarkom RESTful API",
             Version = "v1",
             Contact = new()
             {


### PR DESCRIPTION
## What was done

- Changed the OpenApi title to `RESTful API` instead of `REST API`, because that's more accurate with what we're doing.
- Added descriptions for params in endpoints that used more complex validation rules which aren't covered by `MicroElements.Swashbuckle.FluentValidation` NuGet capabilities.